### PR TITLE
ordered sets of StateData structure update

### DIFF
--- a/examples/LostInTheWoodsExample.cpp
+++ b/examples/LostInTheWoodsExample.cpp
@@ -208,13 +208,13 @@ int main(int argc, char* argv[]) {
   if (interp_enable) {
     cout << "Interpolation enabled!" << endl;
     // process states into estimated and interpolated
-    vector<StateData> interp;
-    vector<StateData> estim;
+    set<StateData> interp;
+    set<StateData> estim;
     for (size_t i = 0; i < all_states.size(); i++) {
       if (i == 0 || i == all_states.size() - 1 || i % interp_period == 0) {
-        estim.push_back(all_states[i]);
+        estim.insert(all_states[i]);
       } else {
-        interp.push_back(all_states[i]);
+        interp.insert(all_states[i]);
         // remove interpolated states from initial values
         initial.erase(all_states[i].pose);
         initial.erase(all_states[i].vel);

--- a/gtsam/nonlinear/StateData.h
+++ b/gtsam/nonlinear/StateData.h
@@ -22,14 +22,17 @@ struct StateData {
   bool operator<(const StateData& other) const {
     return this->time < other.time;
   }
+  // Greater than operator to enable sorting
+  bool operator>(const StateData& other) const {
+    return this->time > other.time;
+  }
+
   // less than operator to compare with other times
   bool operator<(double time) const { return this->time < time; }
-  // equality operator for unordered sets
-  //N
+  // equality operator for unordered sets and maps
   bool operator==(const StateData& other) const {
     return this->pose == other.pose && this->vel == other.vel;
   }
-
 };
 }  // namespace gtsam
 

--- a/gtsam/nonlinear/StateData.h
+++ b/gtsam/nonlinear/StateData.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <gtsam/inference/Key.h>
+
+#include <functional>
+
+namespace gtsam {
+
+/* @brief State data structure for keeping track of pose and velocity keys as
+ * well as associated timestamp. Used in GP interpolation.*/
+struct StateData {
+  Key pose;
+  Key vel;
+  double time;
+  // Default constructor for easy init
+  StateData() = default;
+  // Constructor
+  StateData(Key pose_in, Key vel_in, double time_in)
+      : pose(pose_in), vel(vel_in), time(time_in) {};
+
+  // Less than operator to enable sorting
+  bool operator<(const StateData& other) const {
+    return this->time < other.time;
+  }
+  // less than operator to compare with other times
+  bool operator<(double time) const { return this->time < time; }
+  // equality operator for unordered sets
+  //N
+  bool operator==(const StateData& other) const {
+    return this->pose == other.pose && this->vel == other.vel;
+  }
+
+};
+}  // namespace gtsam
+
+/* @brief Function to make StateData hashable via the pose key. This allows us
+ * to make well-defined unordered sets and maps on StateData structs.
+ * NOTE: hash function combines pose and vel.*/
+namespace std {
+template <>
+struct hash<gtsam::StateData> {
+  std::size_t operator()(const gtsam::StateData& p) const noexcept {
+    return std::hash<uint64_t>()(p.pose) ^ (std::hash<uint64_t>()(p.vel) << 1);
+  }
+};
+}  // namespace std

--- a/gtsam/nonlinear/WNOAInterpFactor.h
+++ b/gtsam/nonlinear/WNOAInterpFactor.h
@@ -42,75 +42,76 @@ class WNOAInterpFactor : public NoiseModelFactor {
 
   // Inner factor that is called on interpolated values
   const NoiseModelFactor::shared_ptr inner_factor_;
-  // List of interpolated states
-  const vector<StateData> interp_states_;
-  // List of estimated states
-  const vector<StateData> estimated_states_;
   // Interpolator class
   const Interpolator<PoseType> interpolator_;
   // disable noise model updates
   const bool fixed_noise_model_;
-  // map interpolated key to index of left estimated state (required for
-  // jacobians)
-  unordered_map<Key, int> interp_key_to_left;
-  // map interpolated state index to estimated state index
-  vector<int> interp_to_estimated;
+  // map keys to interpolated state
+  unordered_map<Key, StateData> key_to_interp;
+  // map interpolated state to border states.
+  unordered_map<StateData, pair<StateData, StateData>> interp_to_borders;
+
   // map outer key to outer key index (for Jacobians)
   unordered_map<Key, int> outer_key_to_index;
 
  public:
+  /* @brief Constructor of WNOA Interpolation Factor. This factor wraps around a
+   * factor that has interpolated states and maps measurements to the bordering
+   * estimated states
+   * estimated_states and interp_states are sets that are ordered on their
+   * defined times. Q_psd is the diagonal of the power spectral density
+   * corresponding to the WNOA model.*/
   WNOAInterpFactor(const NoiseModelFactor::shared_ptr inner_factor,
-                   const vector<StateData> estimated_states,
-                   const vector<StateData> interp_states,
+                   const set<StateData> estimated_states,
+                   const set<StateData> interp_states,
                    const Eigen::Vector<double, dim> Q_psd,
                    const bool fixed_noise_model = false)
       : Base(inner_factor->noiseModel()),
         inner_factor_(inner_factor),
-        interp_states_(interp_states),
-        estimated_states_(estimated_states),
         interpolator_(Q_psd),
         fixed_noise_model_(fixed_noise_model) {
     // PROCESS INTERPOLATED STATES
-    vector<double> estimated_times;  // vector of estimated times
-    for (auto state : estimated_states) {
-      estimated_times.push_back(state.time);
-    }
-    for (size_t i = 0; i < interp_states.size(); i++) {
-      StateData state = interp_states[i];
-      // Search for associated bordering states
-      auto it = std::lower_bound(estimated_times.begin(), estimated_times.end(),
-                                 state.time);
-      if (it == estimated_times.begin()) {
+    // est state iterator
+    auto iter_est_state = estimated_states.begin();
+    // loop through interpolated states
+    for (const StateData& state : interp_states) {
+      // search for estimated state that upper bound current interpolated state
+      iter_est_state =
+          std::lower_bound(iter_est_state, estimated_states.end(), state);
+      if (iter_est_state == estimated_states.begin()) {
         throw runtime_error(
             "Interpolated state time is before all estimated state times");
-      } else if (it == estimated_times.end()) {
+      } else if (iter_est_state == estimated_states.end()) {
         throw runtime_error(
             "Interpolated state time is after all estimated state times");
       } else {
-        // update maps with left index
-        int left_ind = std::distance(estimated_times.begin(), it) - 1;
-        interp_to_estimated.push_back(left_ind);
-        interp_key_to_left[state.pose] = left_ind;
-        interp_key_to_left[state.vel] = left_ind;
+        // decrement iterator (point to left border state)
+        iter_est_state--;
+        // map interp to left border index
+        interp_to_borders[state] = pair(*iter_est_state, *next(iter_est_state));
+        // map keys to interp state
+        key_to_interp[state.pose] = state;
+        key_to_interp[state.vel] = state;
       }
     }
-
     // DEFINE KEYS
     // Go through inner keys and add to outer keys accordingly
     unordered_set<Key> outer_key_set;
     for (Key key : inner_factor->keys()) {
-      if (interp_key_to_left.find(key) == interp_key_to_left.end()) {
+      if (key_to_interp.find(key) == key_to_interp.end()) {
         // inner key is not interpolated, add to outer keys
         outer_key_set.insert(key);
       } else {
         // inner key is interpolated, add associated border state keys
-        int left_ind = interp_key_to_left[key];  // left border index
-        outer_key_set.insert(estimated_states[left_ind].pose);
-        outer_key_set.insert(estimated_states[left_ind].vel);
-        outer_key_set.insert(estimated_states[left_ind + 1].pose);
-        outer_key_set.insert(estimated_states[left_ind + 1].vel);
+        StateData& interp = key_to_interp.at(key);
+        auto [left, right] = interp_to_borders.at(interp);
+        outer_key_set.insert(left.pose);
+        outer_key_set.insert(left.vel);
+        outer_key_set.insert(right.pose);
+        outer_key_set.insert(right.vel);
       }
     }
+    // Convert to key vector
     keys_ = KeyVector(outer_key_set.begin(), outer_key_set.end());
 
     // map outer keys to their associated index (used when mapping jacobians
@@ -167,7 +168,7 @@ class WNOAInterpFactor : public NoiseModelFactor {
     // Call evaluate error to get Jacobians and RHS vector b
     std::vector<Matrix> A(size());
     std::vector<Matrix> JacInner(inner_factor_->size());
-    std::vector<Matrix2N> InterpCondCovs(interp_states_.size());
+    std::unordered_map<StateData, Matrix2N> InterpCondCovs;
     Vector b = -computeInterpolatedError(x, &A, &JacInner, &InterpCondCovs);
     // get interpolated noise model
     auto noise_model = getInterpolatedNoiseModel(JacInner, InterpCondCovs);
@@ -201,7 +202,7 @@ class WNOAInterpFactor : public NoiseModelFactor {
     }
     // Call evaluate error to get inner Jacobians and convariances
     std::vector<Matrix> JacInner(inner_factor_->size());
-    std::vector<Matrix2N> InterpCondCovs(interp_states_.size());
+    std::unordered_map<StateData, Matrix2N> InterpCondCovs;
     Vector b =
         -computeInterpolatedError(x, nullptr, &JacInner, &InterpCondCovs);
     // get interpolated noise model
@@ -214,7 +215,7 @@ class WNOAInterpFactor : public NoiseModelFactor {
   Vector computeInterpolatedError(
       const Values& values, OptionalMatrixVecType H = nullptr,
       OptionalMatrixVecType H_inner = nullptr,
-      vector<Matrix2N>* InterpCondCovs = nullptr) const {
+      unordered_map<StateData, Matrix2N>* InterpCondCovs = nullptr) const {
     // Define mapping from interpolated keys to interpolation jacobians
     // Nested Key: map[interp key][estimated key] = Jac
     unordered_map<Key, unordered_map<Key, Matrix>> InterpJacobians;
@@ -259,20 +260,21 @@ class WNOAInterpFactor : public NoiseModelFactor {
 
     // compute Jacobians for outer keys
     if (H) {
-      // loop through inner keys and update outer keys (backpropagate)
+      // loop through inner keys and update outer keys via backpropagation
+      // NOTE: it is possible for two inner keys to affect the same outer key
       for (size_t i = 0; i < inner_factor_->keys().size(); i++) {
         Key inner_key = inner_factor_->keys()[i];
         if (values_interp.exists(inner_key)) {
-          // get index left bordering state states
-          int left_index = interp_key_to_left.at(inner_key);
-          // get associated outer keys
-          KeyVector outer_keys = {estimated_states_[left_index].pose,
-                                  estimated_states_[left_index].vel,
-                                  estimated_states_[left_index + 1].pose,
-                                  estimated_states_[left_index + 1].vel};
+          // Get interpolated state and border states
+          const StateData& interp = key_to_interp.at(inner_key);
+          const auto& [left, right] = interp_to_borders.at(interp);
+          // Create vector of outer keys
+          KeyVector outer_keys = {left.pose, left.vel, right.pose, right.vel};
           // Loop over keys and update Jacobian
           for (Key& outer_key : outer_keys) {
+            // get position of outer key
             int k = outer_key_to_index.at(outer_key);
+            // add to the outer jacobian
             safeMatrixAdd(
                 (*H)[k], (*H_inner)[i] * InterpJacobians[inner_key][outer_key]);
           }
@@ -292,16 +294,13 @@ class WNOAInterpFactor : public NoiseModelFactor {
   Values getInterpolatedValues(
       const Values& values,
       unordered_map<Key, unordered_map<Key, Matrix>>* InterpJacobians = nullptr,
-      vector<Matrix2N>* InterpCondCovs = nullptr) const {
+      unordered_map<StateData, Matrix2N>* InterpCondCovs = nullptr) const {
     Values values_interp;  // interpolated values
-    // loop through interpolated states and compute interpolation
-    for (size_t i = 0; i < interp_states_.size(); i++) {
-      const StateData& interp_state = interp_states_[i];  // interpolated state
-      int index = interp_to_estimated[i];  // index of bordering estimated state
-      const StateData& left = estimated_states_[index];  // left border state
-      const StateData& right =
-          estimated_states_[index + 1];  // right border state
-      // retrieve estimated states
+    // loop through interpolated state map and compute values
+    for (const auto& [interp_state, border_states] : interp_to_borders) {
+      // unpack border states
+      auto& [left, right] = border_states;
+      // retrieve estimated state values
       const auto state_left = make_pair(values.at<PoseType>(left.pose),
                                         values.at<VelocityType>(left.vel));
       const auto state_right = make_pair(values.at<PoseType>(right.pose),
@@ -341,7 +340,8 @@ class WNOAInterpFactor : public NoiseModelFactor {
         Matrix2N Sigma_tau = interpolator_.computeConditionalCov(
             state_left, state_right, pair(pose, velocity), left.time,
             right.time, interp_state.time);
-        (*InterpCondCovs)[i] = Sigma_tau;  // assumed preallocated vector
+        (*InterpCondCovs)[interp_state] =
+            Sigma_tau;  // assumed preallocated vector
       }
     }
 
@@ -353,7 +353,7 @@ class WNOAInterpFactor : public NoiseModelFactor {
    * interpolated state */
   SharedGaussian getInterpolatedNoiseModel(
       const vector<Matrix>& Jacobians,
-      const vector<Matrix2N>& InterpCondCovs) const {
+      const unordered_map<StateData, Matrix2N>& InterpCondCovs) const {
     // Get noise model of inner factor
     noiseModel::Gaussian::shared_ptr noise_model_ptr =
         dynamic_pointer_cast<noiseModel::Gaussian>(inner_factor_->noiseModel());
@@ -366,16 +366,17 @@ class WNOAInterpFactor : public NoiseModelFactor {
     int err_dim = noise_model_ptr->dim();
     Matrix noise_cov = noise_model_ptr->covariance();
 
-    // Compute the covariance update based on interpolated states
+    // Get mappings from inner keys to index, required to index into jacobian
+    // vector
     KeyVector inner_keys = inner_factor_->keys();
     unordered_map<Key, int> key_index;
     for (size_t i = 0; i < inner_keys.size(); i++) {
       key_index[inner_keys[i]] = i;
     }
+    // Compute the covariance update based on interpolated states
     // Note: Here, we leverage the block-diagonal approximation of the
     // interpolated covariances (i.e., independence approximation)
-    for (size_t i = 0; i < interp_states_.size(); i++) {
-      const StateData& state = interp_states_[i];
+    for (auto& [state, borders] : interp_to_borders) {
       // Retrieve Jacobians from inner factor
       Matrix G_pose(err_dim, dim);
       Matrix G_vel(err_dim, dim);
@@ -392,7 +393,8 @@ class WNOAInterpFactor : public NoiseModelFactor {
       Matrix G_tau(err_dim, 2 * dim);
       G_tau << G_pose, G_vel;
       // add covariance
-      noise_cov += G_tau * InterpCondCovs[i] * G_tau.transpose();
+      const Matrix2N& Sigma_tau = InterpCondCovs.at(state);
+      noise_cov += G_tau * Sigma_tau * G_tau.transpose();
     }
 
     // Return interpolated noise model
@@ -425,10 +427,9 @@ class WNOAInterpFactor : public NoiseModelFactor {
  * to all estimated states. Any factors that do not include any interpolated
  * states are added to the new graph, unaltered.  */
 template <class PoseType>
-NonlinearFactorGraph interpolateFactorGraph(const NonlinearFactorGraph& graph,
-                                            const vector<StateData>& est,
-                                            const vector<StateData>& interp,
-                                            Vector Q_psd) {
+NonlinearFactorGraph interpolateFactorGraph(
+    const NonlinearFactorGraph& graph, const set<StateData>& estimated_states,
+    const set<StateData>& interp_states, Vector Q_psd) {
   // assert that the pose is the right kind of variable
   static_assert(
       std::is_same_v<typename traits<PoseType>::structure_category,
@@ -440,39 +441,42 @@ NonlinearFactorGraph interpolateFactorGraph(const NonlinearFactorGraph& graph,
   assert(traits<PoseType>::dimension == Q_psd.size());
   // Create new factor graph
   NonlinearFactorGraph new_graph;
-  // sort the estimated states
-  vector<StateData> est_srt = est;
-  sort(est_srt.begin(), est_srt.end());
   // Add WNOA prior between all estimated states
-  for (size_t i = 0; i < est_srt.size() - 1; i++) {
+  auto iter_state = estimated_states.begin();
+  while (next(iter_state) != estimated_states.end()) {
+    StateData state_k = *iter_state;
+    StateData state_kp1 = *next(iter_state);
     // get time diff
-    double del_t = est_srt[i + 1].time - est_srt[i].time;
+    double del_t = state_kp1.time - state_k.time;
     // add factor
     auto motion_factor = std::make_shared<WNOAMotionFactor<PoseType>>(
-        est_srt[i].pose, est_srt[i].vel, est_srt[i + 1].pose,
-        est_srt[i + 1].vel, del_t, Q_psd);
+        state_k.pose, state_k.vel, state_kp1.pose, state_kp1.vel, del_t, Q_psd);
     new_graph.add(motion_factor);
+    iter_state++;
   }
   // Get map from keys to interpolated state, and interpolated state to
-  // state.
-  unordered_map<Key, int> key_to_interp;
-  vector<int> interp_to_left_ind(interp.size());
-  for (size_t i = 0; i < interp.size(); i++) {
-    const StateData& state = interp[i];
-    auto it = std::lower_bound(est_srt.begin(), est_srt.end(), state.time);
-    if (it == est_srt.begin()) {
+  // estimated state.
+  unordered_map<Key, StateData> key_to_interp;
+  unordered_map<StateData, pair<StateData, StateData>> interp_to_borders;
+  auto iter_est_state = estimated_states.begin();
+  for (const StateData& state : interp_states) {
+    // search for estimated state that upper bound current interpolated state
+    iter_est_state =
+        std::lower_bound(iter_est_state, estimated_states.end(), state);
+    if (iter_est_state == estimated_states.begin()) {
       throw runtime_error(
           "Interpolated state time is before all estimated state times");
-    } else if (it == est_srt.end()) {
+    } else if (iter_est_state == estimated_states.end()) {
       throw runtime_error(
           "Interpolated state time is after all estimated state times");
     } else {
+      // decrement iterator (point to left border)
+      iter_est_state--;
       // map interp to left border index
-      int left_ind = std::distance(est_srt.begin(), it) - 1;
-      interp_to_left_ind[i] = left_ind;
+      interp_to_borders[state] = pair(*iter_est_state, *next(iter_est_state));
       // map keys to interp state
-      key_to_interp[state.pose] = i;
-      key_to_interp[state.vel] = i;
+      key_to_interp[state.pose] = state;
+      key_to_interp[state.vel] = state;
     }
   }
   // loop through factors and wrap factors on interpolated states
@@ -482,33 +486,24 @@ NonlinearFactorGraph interpolateFactorGraph(const NonlinearFactorGraph& graph,
     // if the factor is a WNOA motion factor, do not add it
     if (dynamic_pointer_cast<WNOAMotionFactor<PoseType>>(factor)) continue;
     // get ordered sets of interpolated and estimated states
-    set<int> interp_inds;
-    set<int> est_inds;
+    set<StateData> factor_interp_states;
+    set<StateData> factor_estimated_states;
     for (Key& key : factor->keys()) {
       // check if key is an interpolated value
       if (key_to_interp.count(key) > 0) {
         // add indices
-        int interp_ind = key_to_interp[key];
-        interp_inds.insert(interp_ind);
-        est_inds.insert(interp_to_left_ind[interp_ind]);
-        est_inds.insert(interp_to_left_ind[interp_ind] + 1);
+        StateData interp_state = key_to_interp[key];
+        factor_interp_states.insert(interp_state);
+        auto [left, right] = interp_to_borders.at(interp_state);
+        factor_estimated_states.insert(left);
+        factor_estimated_states.insert(right);
       }
     }
     // add factor to new graph
-    if (interp_inds.size() == 0) {
-      // factor does not require interpolation, just add
+    if (factor_interp_states.size() == 0) {
+      // factor does not require interpolation, just add factor as is
       new_graph.add(factor);
     } else {
-      // get interpolated states
-      vector<StateData> factor_interp_states;
-      for (auto ind : interp_inds) {
-        factor_interp_states.push_back(interp[ind]);
-      }
-      // get bordering states
-      vector<StateData> factor_est_states;
-      for (auto ind : est_inds) {
-        factor_est_states.push_back(est_srt[ind]);
-      }
       // Downcast the NonlinearFactor to a NoiseModelFactor
       auto nmfactor = dynamic_pointer_cast<NoiseModelFactor>(factor);
       assert(nmfactor &&
@@ -516,7 +511,7 @@ NonlinearFactorGraph interpolateFactorGraph(const NonlinearFactorGraph& graph,
 
       // Define and add factor to new graph
       const auto wrapped_factor = std::make_shared<WNOAInterpFactor<PoseType>>(
-          nmfactor, factor_est_states, factor_interp_states, Q_psd);
+          nmfactor, factor_estimated_states, factor_interp_states, Q_psd);
       new_graph.add(wrapped_factor);
     }
   }
@@ -527,8 +522,8 @@ NonlinearFactorGraph interpolateFactorGraph(const NonlinearFactorGraph& graph,
 template <class PoseType>
 Values updateInterpValues(const NonlinearFactorGraph& interp_graph,
                           const Values& values,
-                          const vector<StateData>& estim_states,
-                          const vector<StateData>& interp_states,
+                          const set<StateData>& estim_states,
+                          const set<StateData>& interp_states,
                           const Vector Q_psd) {
   // assert that the pose is the right kind of variable
   static_assert(

--- a/gtsam/nonlinear/WNOAInterpFactor.h
+++ b/gtsam/nonlinear/WNOAInterpFactor.h
@@ -11,6 +11,7 @@
 #include <gtsam/inference/Key.h>
 #include <gtsam/nonlinear/Interpolator.h>
 #include <gtsam/nonlinear/NonlinearFactor.h>
+#include <gtsam/nonlinear/StateData.h>
 #include <gtsam/nonlinear/Values.h>
 
 #include <algorithm>
@@ -22,27 +23,6 @@
 using namespace std;
 
 namespace gtsam {
-
-/* @brief State data structure for keeping track of pose and velocity keys as
- * well as associated timestamp. Used in GP interpolation.*/
-struct StateData {
-  Key pose;
-  Key vel;
-  double time;
-  // Default constructor for easy init
-  StateData() = default;
-  // Constructor
-  StateData(Key pose_in, Key vel_in, double time_in)
-      : pose(pose_in), vel(vel_in), time(time_in) {};
-
-  // Less than operator to enable sorting for vectors
-  bool operator<(const StateData& other) const {
-    return this->time < other.time;
-  }
-  // less than operator to compare with other times
-  bool operator<(double time) const { return this->time < time; }
-};
-
 /* Wrapper class that allows a variable of a factor to be replaced by a WNOA
  * interpolation.
  * It is assumed that estimated state entries are sorted by time.

--- a/gtsam/nonlinear/tests/testWNOAInterpFactor.cpp
+++ b/gtsam/nonlinear/tests/testWNOAInterpFactor.cpp
@@ -63,11 +63,11 @@ static Vector6 v4_se3 = v0_se3;
 
 // Define interpolation parameters
 // Add random border and interpolated states
-static vector<StateData> border = {StateData(P(0), V(0), 0.0),
-                                   StateData(P(2), V(2), 2 * timestep),
-                                   StateData(P(3), V(3), 100 * timestep)};
-static vector<StateData> interp = {StateData(P(1), V(1), timestep),
-                                   StateData(P(4), V(4), timestep)};
+static set<StateData> border = {StateData(P(0), V(0), 0.0),
+                                StateData(P(2), V(2), 2 * timestep),
+                                StateData(P(3), V(3), 100 * timestep)};
+static set<StateData> interp = {StateData(P(1), V(1), timestep),
+                                StateData(P(4), V(4), timestep)};
 
 // STATE DATA TESTS
 
@@ -92,7 +92,6 @@ TEST(StateData, OrderedSet) {
     EXPECT(state.pose == key_order[i]);
     i++;
   }
-
 }
 
 // hash map
@@ -257,11 +256,11 @@ TEST(WNOAInterp, EvalErrorSE3BetweenPose) {
 TEST(WNOAInterp, EvalErrorSE3BtwnInterp) {
   // Same as between above, but using two interpolated states with different
   // boundaries
-  vector<StateData> border = {StateData(P(0), V(0), 0.0),
-                              StateData(P(2), V(2), 2 * timestep),
-                              StateData(P(4), V(4), 4 * timestep)};
-  vector<StateData> interp = {StateData(P(1), V(1), timestep),
-                              StateData(P(3), V(3), 3 * timestep)};
+  set<StateData> border = {StateData(P(0), V(0), 0.0),
+                           StateData(P(2), V(2), 2 * timestep),
+                           StateData(P(4), V(4), 4 * timestep)};
+  set<StateData> interp = {StateData(P(1), V(1), timestep),
+                           StateData(P(3), V(3), 3 * timestep)};
   const Pose3 p3_se3 = p0_se3.expmap(3 * timestep * v0_se3);
   const Pose3 p4_se3 = p0_se3.expmap(4 * timestep * v0_se3);
   Vector6 v2_se3 = v0_se3;
@@ -495,11 +494,11 @@ TEST(WNOAInterp, NoiseModelSE3Unary) {
 TEST(WNOAInterp, NoiseModelSE3Btwn) {
   // Same as between above, but using two interpolated states with different
   // boundaries
-  vector<StateData> border = {StateData(P(0), V(0), 0.0),
-                              StateData(P(2), V(2), 2 * timestep),
-                              StateData(P(4), V(4), 4 * timestep)};
-  vector<StateData> interp = {StateData(P(1), V(1), timestep),
-                              StateData(P(3), V(3), 3 * timestep)};
+  set<StateData> border = {StateData(P(0), V(0), 0.0),
+                           StateData(P(2), V(2), 2 * timestep),
+                           StateData(P(4), V(4), 4 * timestep)};
+  set<StateData> interp = {StateData(P(1), V(1), timestep),
+                           StateData(P(3), V(3), 3 * timestep)};
   const Pose3 p3_se3 = p0_se3.expmap(3 * timestep * v0_se3);
   const Pose3 p4_se3 = p0_se3.expmap(4 * timestep * v0_se3);
   Vector6 v2_se3 = v0_se3;
@@ -536,11 +535,11 @@ TEST(WNOAInterp, NoiseModelSE3Btwn) {
 TEST(WNOAInterp, NoiseModelP3Btwn) {
   // Same as between above, but using two interpolated states with different
   // boundaries
-  vector<StateData> border = {StateData(P(0), V(0), 0.0),
-                              StateData(P(2), V(2), 2 * timestep),
-                              StateData(P(4), V(4), 4 * timestep)};
-  vector<StateData> interp = {StateData(P(1), V(1), timestep),
-                              StateData(P(3), V(3), 3 * timestep)};
+  set<StateData> border = {StateData(P(0), V(0), 0.0),
+                           StateData(P(2), V(2), 2 * timestep),
+                           StateData(P(4), V(4), 4 * timestep)};
+  set<StateData> interp = {StateData(P(1), V(1), timestep),
+                           StateData(P(3), V(3), 3 * timestep)};
   // const Point3 p3_p3 = p0_p3 + 3 * timestep * v0_p3;
   const Point3 p4_p3 = p0_p3 + 4 * timestep * v0_p3;
   Vector3 v2_p3 = v0_p3;
@@ -581,11 +580,11 @@ TEST(WNOAInterp, NoiseModelP3Btwn) {
 TEST(WNOAInterp, LinearizeSE3Btwn) {
   // Same as between above, but using two interpolated states with different
   // boundaries
-  vector<StateData> border = {StateData(P(0), V(0), 0.0),
-                              StateData(P(2), V(2), 2 * timestep),
-                              StateData(P(4), V(4), 4 * timestep)};
-  vector<StateData> interp = {StateData(P(1), V(1), timestep),
-                              StateData(P(3), V(3), 3 * timestep)};
+  set<StateData> border = {StateData(P(0), V(0), 0.0),
+                           StateData(P(2), V(2), 2 * timestep),
+                           StateData(P(4), V(4), 4 * timestep)};
+  set<StateData> interp = {StateData(P(1), V(1), timestep),
+                           StateData(P(3), V(3), 3 * timestep)};
   const Pose3 p3_se3 = p0_se3.expmap(3 * timestep * v0_se3);
   const Pose3 p4_se3 = p0_se3.expmap(4 * timestep * v0_se3);
   Vector6 v2_se3 = v0_se3;
@@ -623,11 +622,11 @@ TEST(WNOAInterp, SE3OptimTest) {
   //  0 ---- 1 ---- 2 ----- 3 ----- 4
   //  e      i      e       i       e
   //          --- between ---
-  vector<StateData> border = {StateData(P(0), V(0), 0.0),
-                              StateData(P(2), V(2), 2 * timestep),
-                              StateData(P(4), V(4), 4 * timestep)};
-  vector<StateData> interp = {StateData(P(1), V(1), timestep),
-                              StateData(P(3), V(3), 3 * timestep)};
+  set<StateData> border = {StateData(P(0), V(0), 0.0),
+                           StateData(P(2), V(2), 2 * timestep),
+                           StateData(P(4), V(4), 4 * timestep)};
+  set<StateData> interp = {StateData(P(1), V(1), timestep),
+                           StateData(P(3), V(3), 3 * timestep)};
   const Pose3 p3_se3 = p0_se3.expmap(3 * timestep * v0_se3);
   const Pose3 p4_se3 = p0_se3.expmap(4 * timestep * v0_se3);
   // Define nominal factors
@@ -720,11 +719,11 @@ TEST(WNOAInterp, SE3InterpGraph) {
   graph.add(prior_vel_factor);
 
   // Interpolate the graph
-  vector<StateData> border_shfl = {StateData(P(0), V(0), 0.0),
-                                   StateData(P(4), V(4), 4 * timestep),
-                                   StateData(P(2), V(2), 2 * timestep)};
-  vector<StateData> interp_shfl = {StateData(P(3), V(3), 3 * timestep),
-                                   StateData(P(1), V(1), timestep)};
+  set<StateData> border_shfl = {StateData(P(0), V(0), 0.0),
+                                StateData(P(4), V(4), 4 * timestep),
+                                StateData(P(2), V(2), 2 * timestep)};
+  set<StateData> interp_shfl = {StateData(P(3), V(3), 3 * timestep),
+                                StateData(P(1), V(1), timestep)};
   auto new_graph =
       interpolateFactorGraph<Pose3>(graph, border_shfl, interp_shfl, Q_se3);
 

--- a/gtsam/nonlinear/tests/testWNOAInterpFactor.cpp
+++ b/gtsam/nonlinear/tests/testWNOAInterpFactor.cpp
@@ -16,7 +16,9 @@
 #include <gtsam/nonlinear/WNOAInterpFactor.h>
 #include <gtsam/slam/BetweenFactor.h>
 
+#include <set>
 #include <unordered_map>
+#include <unordered_set>
 
 using namespace std;
 using namespace gtsam;
@@ -66,6 +68,49 @@ static vector<StateData> border = {StateData(P(0), V(0), 0.0),
                                    StateData(P(3), V(3), 100 * timestep)};
 static vector<StateData> interp = {StateData(P(1), V(1), timestep),
                                    StateData(P(4), V(4), timestep)};
+
+// STATE DATA TESTS
+
+// Constructor
+TEST(StateData, Constructor) { StateData(P(0), V(0), 0.0); }
+
+// Ordered Set
+TEST(StateData, OrderedSet) {
+  // define set
+  set<StateData> sd_set;
+  // add to set in inverse order
+  sd_set.insert(StateData(P(4), V(4), 3.0));
+  sd_set.insert(StateData(P(3), V(3), 2.00001));
+  sd_set.insert(StateData(P(2), V(2), 2.0));
+  sd_set.insert(StateData(P(1), V(1), 1.0));
+  sd_set.insert(StateData(P(0), V(0), 0.0));
+  // verify the order of the set
+  KeyVector key_order = {P(0), P(1), P(2), P(3), P(4)};
+  int i = 0;
+  for (auto state : sd_set) {
+    cout << DefaultKeyFormatter(state.pose) << endl;
+    EXPECT(state.pose == key_order[i]);
+    i++;
+  }
+
+}
+
+// hash map
+TEST(StateData, UnorderedSet) {
+  // define set
+  unordered_set<StateData> sd_set;
+  // add to set in inverse order
+  sd_set.insert(StateData(P(2), V(2), 2.0));
+  sd_set.insert(StateData(P(1), V(1), 1.0));
+  sd_set.insert(StateData(P(0), V(0), 0.0));
+  EXPECT(sd_set.size() == 3);
+  // insert new state with existing pose and vel (but mixed)
+  sd_set.insert(StateData(P(0), V(1), 0.0));
+  EXPECT(sd_set.size() == 4);
+  // insert new state with same pose and vel but diff time (should not add)
+  sd_set.insert(StateData(P(0), V(0), 0.1));
+  EXPECT(sd_set.size() == 4);
+}
 
 // Constructor test
 TEST(WNOAInterp, Constructor) {
@@ -703,7 +748,8 @@ TEST(WNOAInterp, SE3InterpGraph) {
   DOUBLES_EQUAL(0.0, optimizer.error(), 1e-6);
 
   // Test value interpolation
-  Values result_interp = updateInterpValues<Pose3>(new_graph, result, border_shfl, interp_shfl, Q_se3);
+  Values result_interp = updateInterpValues<Pose3>(
+      new_graph, result, border_shfl, interp_shfl, Q_se3);
 
   auto p3_se3_est = result_interp.at<Pose3>(P(3));
   auto p1_se3_est = result_interp.at<Pose3>(P(1));


### PR DESCRIPTION
WNOAInterpFactor now uses ordered sets of StateData structures. Major changes:
- all internal data wrt states in factor are tracked with two unordered maps: key to interpolated state and interp to border states. It turns out this is all we need
- use of maps ensures that input data is sorted -> more efficient processing
- removed internal storage of vectors of states
- Interpolated covariances are now stored in a map on interpolated states, to avoid risk of indexing error
- Now make extensive use of iterators through maps.