### PR TITLE
Changing computation of Lambda and Psi to be more efficient

### DIFF
--- a/examples/Data/LostInTheWoods.yaml
+++ b/examples/Data/LostInTheWoods.yaml
@@ -15,7 +15,7 @@ flags:
   wnoa: true
   br: true
   gt_init: false
-  solve_slam: true
+  solve_slam: false
 interp:
   enable: true
   interp_period: 10 

--- a/gtsam/nonlinear/Interpolator.cpp
+++ b/gtsam/nonlinear/Interpolator.cpp
@@ -404,6 +404,30 @@ Interpolator<PoseType>::getLambdaPsi(double t_k, double t_kp1,
     return std::make_pair(Lambda, Psi);
 }
 
+
+template <typename PoseType>
+std::pair<Matrix, Matrix>
+Interpolator<PoseType>::getLambdaPsiGeneral(double t_k, double t_kp1,
+                                    double t_tau) const {
+
+    // Build transition matrices for all combinations
+    double dt = t_kp1 - t_k;
+    auto Phi_12 = transitionFunction_(dt);
+    auto Phi_1tau = transitionFunction_(t_tau - t_k);
+    auto Phi_tau2 = transitionFunction_(t_kp1 - t_tau);
+
+    // Construct Q
+    auto Q_12_inv = inverseCovarianceFunction_(dt, Q_psd_);
+    auto Q_1tau = covarianceFunction_(t_tau - t_k, Q_psd_);
+
+    // Eq. (11.41) in the book
+    auto Lambda =
+        Phi_1tau - Q_1tau * Phi_tau2.transpose() * Q_12_inv * Phi_12;
+    auto Psi = Q_1tau * Phi_tau2.transpose() * Q_12_inv;
+
+    return std::make_pair(Lambda, Psi);
+}
+
 template <typename PoseType>
 typename Interpolator<PoseType>::Matrix2N
 Interpolator<PoseType>::computeConditionalCov(

--- a/gtsam/nonlinear/Interpolator.cpp
+++ b/gtsam/nonlinear/Interpolator.cpp
@@ -144,20 +144,16 @@ Interpolator<PoseType>::interpolatePoseAndVelocity(
 
     } else {
 
-      Matrix2N Lambda,
-          Psi;  // ensure Lambda and Psi are 2*dim x 2*dim matrices,
-                // rather than using auto in the line below
+      Matrix2 Lambda,
+          Psi;  // ensure Lambda and Psi are 2x2 matrices
+                // technically they are 2N x 2N, but each block is block-diagonal with one constant
+                // This is specific to WNOA, so we might need to change this once we do WNOJ/WNOV
       std::tie(Lambda, Psi) = getLambdaPsi(t_k, t_kp1, t_tau);
 
-      MatrixNx2N Lambda_1 = Lambda.topRows(dim);
-      MatrixNx2N Lambda_2 = Lambda.bottomRows(dim);
-      MatrixNx2N Psi_1 = Psi.topRows(dim);
-      MatrixNx2N Psi_2 = Psi.bottomRows(dim);
-
       // form quantities for Eq. (11.45) in the book, (5.13) in the paper
-      Vector2N gamma_k;
-      gamma_k.topRows(dim).setZero();
-      gamma_k.bottomRows(dim) = varpi_k;
+      VectorN xi_k, xi_dot_k;
+      xi_k.setZero();
+      xi_dot_k = varpi_k;
 
       // Note that p1 = T(t_k), p2 = T(t_{k+1})
       //  compute xi = log(T_k^-1 T_{k+1})^check
@@ -178,11 +174,12 @@ Interpolator<PoseType>::interpolatePoseAndVelocity(
                                       &right_jac_inv);
       }
 
-      Vector2N gamma_kp1;
-      gamma_kp1 << xi, right_jac_inv * varpi_kp1;
+      VectorN xi_kp1, xi_dot_kp1;
+      xi_kp1 << xi;
+      xi_dot_kp1 = right_jac_inv * varpi_kp1;
 
-      auto xi_tau = Lambda_1 * gamma_k + Psi_1 * gamma_kp1;
-      auto xidot_tau = Lambda_2 * gamma_k + Psi_2 * gamma_kp1;
+      VectorN xi_tau = Lambda(0,1) * xi_dot_k + Psi(0,0) * xi_kp1 + Psi(0,1) * xi_dot_kp1; // Dropping xi_k term here since it's zero
+      VectorN xidot_tau = Lambda(1,1) * xi_dot_k + Psi(1,0) * xi_kp1 + Psi(1,1) * xi_dot_kp1; // Dropping xi_k term here since it's zero
       // Eq. (11.45) in Barfoot 2025
       MatrixN right_jac_tau;
       MatrixN dTtau_dTk;
@@ -216,23 +213,22 @@ Interpolator<PoseType>::interpolatePoseAndVelocity(
           dvarpitau_dxitau = PoseType::adjointMap(xidot_tau) / 2.0;
         }
         // dgammakp1
-        Eigen::Matrix<double, 2 * dim, dim> dgammakp1_dTk;
-        dgammakp1_dTk << dxi_dTk, dxidot_dxi * dxi_dTk;
-        Eigen::Matrix<double, 2 * dim, dim> dgammakp1_dTkp1;
-        dgammakp1_dTkp1 << dxi_dTkp1, dxidot_dxi * dxi_dTkp1;
-        Eigen::Matrix<double, 2 * dim, dim> dgammakp1_dvarpikp1;
-        dgammakp1_dvarpikp1 << Eigen::Matrix<double, dim, dim>::Zero(),
-            right_jac_inv;
+        Eigen::Matrix<double, dim, dim> dxidot_dTk;
+        dxidot_dTk << dxidot_dxi * dxi_dTk;
+        Eigen::Matrix<double, dim, dim> dxidot_dTkp1;
+        dxidot_dTkp1 << dxidot_dxi * dxi_dTkp1;
+        Eigen::Matrix<double,dim, dim> dxidotkp1_dvarpikp1;
+        dxidotkp1_dvarpikp1 << right_jac_inv;
         // dxitau
-        MatrixN dxitau_dTk = Psi_1 * dgammakp1_dTk;
-        MatrixN dxitau_dvarpik = Lambda_1.template block<dim, dim>(0, dim);
-        MatrixN dxitau_dTkp1 = Psi_1 * dgammakp1_dTkp1;
-        MatrixN dxitau_dvarpikp1 = Psi_1 * dgammakp1_dvarpikp1;
+        MatrixN dxitau_dTk = Psi(0,0) * dxi_dTk + Psi(0,1) * dxidot_dTk; 
+        MatrixN dxitau_dvarpik = Lambda(0,1) * MatrixN::Identity(); // xi does not depend on varpi_k and xi_dot is exactly varpi_k
+        MatrixN dxitau_dTkp1 = Psi(0,0) * dxi_dTkp1 + Psi(0,1) * dxidot_dTkp1;
+        MatrixN dxitau_dvarpikp1 = Psi(0,1) * dxidotkp1_dvarpikp1; // dxikp1 does not depend on varpi_kp1
         // dxidottau
-        MatrixN dxidottau_dTk = Psi_2 * dgammakp1_dTk;
-        MatrixN dxidottau_dvarpik = Lambda_2.template block<dim, dim>(0, dim);
-        MatrixN dxidottau_dTkp1 = Psi_2 * dgammakp1_dTkp1;
-        MatrixN dxidottau_dvarpikp1 = Psi_2 * dgammakp1_dvarpikp1;
+        MatrixN dxidottau_dTk = Psi(1,0) * dxi_dTk + Psi(1,1) * dxidot_dTk;
+        MatrixN dxidottau_dvarpik = Lambda(1,1) * MatrixN::Identity(); // xi does not depend on varpi_k and xi_dot is exactly varpi_k
+        MatrixN dxidottau_dTkp1 = Psi(1,0) * dxi_dTkp1 + Psi(1,1) * dxidot_dTkp1;
+        MatrixN dxidottau_dvarpikp1 = Psi(1,1) * dxidotkp1_dvarpikp1; // dxikp1 does not depend on varpi_kp1
 
         // dTtau_dTk
         (*H)[0] = dTtau_dTk + dTtau_dxitau * dxitau_dTk;
@@ -270,7 +266,8 @@ Interpolator<PoseType>::interpolatePoseAndVelocity(
 
         // use existing Lambda and Psi computed from (11.41) in the book
         Matrix2N Sigma = computeConditionalCov(tPoseVel_k, tPoseVel_kp1, TimestampedPoseVel{poseVel_tau, t_tau});
-        LambdaPsi << Lambda, Psi;
+        LambdaPsi << MatrixN::Identity()*Lambda(0,0), MatrixN::Identity()*Lambda(0,1), MatrixN::Identity()*Psi(0,0), MatrixN::Identity()*Psi(0,1),
+                     MatrixN::Identity()*Lambda(1,0), MatrixN::Identity()*Lambda(1,1), MatrixN::Identity()*Psi(1,0), MatrixN::Identity()*Psi(1,1);
 
         *covarianceOut = Sigma + LambdaPsi * *mainSolveMarginalMatrix * LambdaPsi.transpose();
       }
@@ -381,20 +378,28 @@ std::pair<Matrix, Matrix>
 Interpolator<PoseType>::getLambdaPsi(double t_k, double t_kp1,
                                     double t_tau) const {
 
-    // Build transition matrices for all combinations
+
+
+    // TODO (SL): This is currently hardcoded for WNOA.
+    // we might want to move this code into the WNOA-specific factor and call it?
     double dt = t_kp1 - t_k;
-    auto Phi_12 = transitionFunction_(dt);
-    auto Phi_1tau = transitionFunction_(t_tau - t_k);
-    auto Phi_tau2 = transitionFunction_(t_kp1 - t_tau);
+    double alpha  = (t_tau - t_k) / dt;
+    double alpha2 = alpha * alpha;
+    double alpha3 = alpha2 * alpha;
 
-    // Construct Q
-    auto Q_12_inv = inverseCovarianceFunction_(dt, Q_psd_);
-    auto Q_1tau = covarianceFunction_(t_tau - t_k, Q_psd_);
 
-    // Eq. (11.41) in the book
-    auto Lambda =
-        Phi_1tau - Q_1tau * Phi_tau2.transpose() * Q_12_inv * Phi_12;
-    auto Psi = Q_1tau * Phi_tau2.transpose() * Q_12_inv;
+    Matrix2 Lambda, Psi;
+
+    Psi(0,0) = 3*alpha2 - 2*alpha3;
+    Psi(0,1) = dt*(alpha3 - alpha2);
+    Psi(1,0) = (6*alpha/dt) - (6*alpha2/dt);
+    Psi(1,1) = 3*alpha2 - 2*alpha;
+
+    Lambda(0,0) = 1 - Psi(0,0);
+    Lambda(0,1) = dt*(alpha - 2*alpha2 + alpha3);
+    Lambda(1,0) = -Psi(1,0);
+    Lambda(1,1) = 1 - 4*alpha + 3*alpha2;
+
 
     return std::make_pair(Lambda, Psi);
 }

--- a/gtsam/nonlinear/Interpolator.cpp
+++ b/gtsam/nonlinear/Interpolator.cpp
@@ -144,10 +144,8 @@ Interpolator<PoseType>::interpolatePoseAndVelocity(
 
     } else {
 
-      Matrix2 Lambda,
-          Psi;  // ensure Lambda and Psi are 2x2 matrices
-                // technically they are 2N x 2N, but each block is block-diagonal with one constant
-                // This is specific to WNOA, so we might need to change this once we do WNOJ/WNOV
+      Matrix2N Lambda,
+          Psi;  // ensure Lambda and Psi are 2Nx2N matrices
       std::tie(Lambda, Psi) = getLambdaPsi(t_k, t_kp1, t_tau);
 
       // form quantities for Eq. (11.45) in the book, (5.13) in the paper
@@ -178,8 +176,8 @@ Interpolator<PoseType>::interpolatePoseAndVelocity(
       xi_kp1 << xi;
       xi_dot_kp1 = right_jac_inv * varpi_kp1;
 
-      VectorN xi_tau = Lambda(0,1) * xi_dot_k + Psi(0,0) * xi_kp1 + Psi(0,1) * xi_dot_kp1; // Dropping xi_k term here since it's zero
-      VectorN xidot_tau = Lambda(1,1) * xi_dot_k + Psi(1,0) * xi_kp1 + Psi(1,1) * xi_dot_kp1; // Dropping xi_k term here since it's zero
+      VectorN xi_tau = Lambda(0,dim) * xi_dot_k + Psi(0,0) * xi_kp1 + Psi(0,dim) * xi_dot_kp1; // Dropping xi_k term here since it's zero
+      VectorN xidot_tau = Lambda(dim,dim) * xi_dot_k + Psi(dim,0) * xi_kp1 + Psi(dim,dim) * xi_dot_kp1; // Dropping xi_k term here since it's zero
       // Eq. (11.45) in Barfoot 2025
       MatrixN right_jac_tau;
       MatrixN dTtau_dTk;
@@ -220,15 +218,15 @@ Interpolator<PoseType>::interpolatePoseAndVelocity(
         Eigen::Matrix<double,dim, dim> dxidotkp1_dvarpikp1;
         dxidotkp1_dvarpikp1 << right_jac_inv;
         // dxitau
-        MatrixN dxitau_dTk = Psi(0,0) * dxi_dTk + Psi(0,1) * dxidot_dTk; 
-        MatrixN dxitau_dvarpik = Lambda(0,1) * MatrixN::Identity(); // xi does not depend on varpi_k and xi_dot is exactly varpi_k
-        MatrixN dxitau_dTkp1 = Psi(0,0) * dxi_dTkp1 + Psi(0,1) * dxidot_dTkp1;
-        MatrixN dxitau_dvarpikp1 = Psi(0,1) * dxidotkp1_dvarpikp1; // dxikp1 does not depend on varpi_kp1
+        MatrixN dxitau_dTk = Psi(0,0) * dxi_dTk + Psi(0,dim) * dxidot_dTk; 
+        MatrixN dxitau_dvarpik = Lambda(0,dim) * MatrixN::Identity(); // xi does not depend on varpi_k and xi_dot is exactly varpi_k
+        MatrixN dxitau_dTkp1 = Psi(0,0) * dxi_dTkp1 + Psi(0,dim) * dxidot_dTkp1;
+        MatrixN dxitau_dvarpikp1 = Psi(0,dim) * dxidotkp1_dvarpikp1; // dxikp1 does not depend on varpi_kp1
         // dxidottau
-        MatrixN dxidottau_dTk = Psi(1,0) * dxi_dTk + Psi(1,1) * dxidot_dTk;
-        MatrixN dxidottau_dvarpik = Lambda(1,1) * MatrixN::Identity(); // xi does not depend on varpi_k and xi_dot is exactly varpi_k
-        MatrixN dxidottau_dTkp1 = Psi(1,0) * dxi_dTkp1 + Psi(1,1) * dxidot_dTkp1;
-        MatrixN dxidottau_dvarpikp1 = Psi(1,1) * dxidotkp1_dvarpikp1; // dxikp1 does not depend on varpi_kp1
+        MatrixN dxidottau_dTk = Psi(dim,0) * dxi_dTk + Psi(dim,dim) * dxidot_dTk;
+        MatrixN dxidottau_dvarpik = Lambda(dim,dim) * MatrixN::Identity(); // xi does not depend on varpi_k and xi_dot is exactly varpi_k
+        MatrixN dxidottau_dTkp1 = Psi(dim,0) * dxi_dTkp1 + Psi(dim,dim) * dxidot_dTkp1;
+        MatrixN dxidottau_dvarpikp1 = Psi(dim,dim) * dxidotkp1_dvarpikp1; // dxikp1 does not depend on varpi_kp1
 
         // dTtau_dTk
         (*H)[0] = dTtau_dTk + dTtau_dxitau * dxitau_dTk;
@@ -266,9 +264,7 @@ Interpolator<PoseType>::interpolatePoseAndVelocity(
 
         // use existing Lambda and Psi computed from (11.41) in the book
         Matrix2N Sigma = computeConditionalCov(tPoseVel_k, tPoseVel_kp1, TimestampedPoseVel{poseVel_tau, t_tau});
-        LambdaPsi << MatrixN::Identity()*Lambda(0,0), MatrixN::Identity()*Lambda(0,1), MatrixN::Identity()*Psi(0,0), MatrixN::Identity()*Psi(0,1),
-                     MatrixN::Identity()*Lambda(1,0), MatrixN::Identity()*Lambda(1,1), MatrixN::Identity()*Psi(1,0), MatrixN::Identity()*Psi(1,1);
-
+        LambdaPsi <<  Lambda, Psi;
         *covarianceOut = Sigma + LambdaPsi * *mainSolveMarginalMatrix * LambdaPsi.transpose();
       }
       return poseVel_tau;
@@ -388,17 +384,23 @@ Interpolator<PoseType>::getLambdaPsi(double t_k, double t_kp1,
     double alpha3 = alpha2 * alpha;
 
 
-    Matrix2 Lambda, Psi;
+    Matrix2N Lambda, Psi;
 
-    Psi(0,0) = 3*alpha2 - 2*alpha3;
-    Psi(0,1) = dt*(alpha3 - alpha2);
-    Psi(1,0) = (6*alpha/dt) - (6*alpha2/dt);
-    Psi(1,1) = 3*alpha2 - 2*alpha;
+    double Psi_00 = 3*alpha2 - 2*alpha3;
+    double Psi_01 = dt*(alpha3 - alpha2);
+    double Psi_10 = (6*alpha/dt) - (6*alpha2/dt);
+    double Psi_11 = 3*alpha2 - 2*alpha;
 
-    Lambda(0,0) = 1 - Psi(0,0);
-    Lambda(0,1) = dt*(alpha - 2*alpha2 + alpha3);
-    Lambda(1,0) = -Psi(1,0);
-    Lambda(1,1) = 1 - 4*alpha + 3*alpha2;
+    double Lambda_00 = 1 - Psi_00;
+    double Lambda_01 = dt*(alpha - 2*alpha2 + alpha3);
+    double Lambda_10 = -Psi_10;
+    double Lambda_11 = 1 - 4*alpha + 3*alpha2;
+
+    Lambda << MatrixN::Identity()*Lambda_00, MatrixN::Identity()*Lambda_01,
+              MatrixN::Identity()*Lambda_10, MatrixN::Identity()*Lambda_11;
+
+    Psi << MatrixN::Identity()*Psi_00, MatrixN::Identity()*Psi_01,
+           MatrixN::Identity()*Psi_10, MatrixN::Identity()*Psi_11;
 
 
     return std::make_pair(Lambda, Psi);

--- a/gtsam/nonlinear/Interpolator.h
+++ b/gtsam/nonlinear/Interpolator.h
@@ -149,6 +149,9 @@ class Interpolator {
 
   std::pair<Matrix, Matrix> getLambdaPsi(double t_k, double t_kp1,
                                         double t_tau) const;
+
+  std::pair<Matrix, Matrix> getLambdaPsiGeneral(double t_k, double t_kp1,
+                                        double t_tau) const;
   
   // if Lambda and Psi are provided, they will be computed using (5.23)
   Matrix2N computeConditionalCov(const TimestampedPoseVel& pvk,

--- a/gtsam/nonlinear/tests/testInterpolator.cpp
+++ b/gtsam/nonlinear/tests/testInterpolator.cpp
@@ -793,9 +793,13 @@ TEST(Interpolator, LambdaPsiConsistencyP2) {
   Interpolator<Point2> interpolator(Q_p2);
   for (double ratio = 0.1; ratio <= 0.9; ratio += 0.1) {
     // get lambda and psi using Eq. (11.41) in the book
-    auto [Lambda_book, Psi_book] = interpolator.getLambdaPsi(
+    auto [Lambda_tmp, Psi_tmp] = interpolator.getLambdaPsi(
         0.0, timestep, timestep * ratio);
-
+    Eigen::Matrix<double, 4, 4> Lambda_book, Psi_book;
+    Lambda_book << Eigen::Matrix2d::Identity()*Lambda_tmp(0,0), Eigen::Matrix2d::Identity()*Lambda_tmp(0,1),
+        Eigen::Matrix2d::Identity()*Lambda_tmp(1,0), Eigen::Matrix2d::Identity()*Lambda_tmp(1,1);
+    Psi_book << Eigen::Matrix2d::Identity()*Psi_tmp(0,0), Eigen::Matrix2d::Identity()*Psi_tmp(0,1),
+        Eigen::Matrix2d::Identity()*Psi_tmp(1,0), Eigen::Matrix2d::Identity()*Psi_tmp(1,1);
     // get lambda and psi using Eq. (5.23) in the paper
     auto tpvk = TimestampedPoseVelocity<Point2>(p0_p2, v0_p2, 0.0);
     auto tpvkp1 = TimestampedPoseVelocity<Point2>(p1_p2, v1_p2, timestep);
@@ -815,8 +819,14 @@ TEST(Interpolator, LambdaPsiConsistencyP3) {
   Interpolator<Point3> interpolator(Q_p3);
   for (double ratio = 0.1; ratio <= 0.9; ratio += 0.1) {
     // get lambda and psi using Eq. (11.41) in the book
-    auto [Lambda_book, Psi_book] = interpolator.getLambdaPsi(
+    auto [Lambda_tmp, Psi_tmp] = interpolator.getLambdaPsi(
         0.0, timestep, timestep * ratio);
+    
+    Eigen::Matrix<double, 6, 6> Lambda_book, Psi_book;
+    Lambda_book << Eigen::Matrix3d::Identity()*Lambda_tmp(0,0), Eigen::Matrix3d::Identity()*Lambda_tmp(0,1),
+        Eigen::Matrix3d::Identity()*Lambda_tmp(1,0), Eigen::Matrix3d::Identity()*Lambda_tmp(1,1);
+    Psi_book << Eigen::Matrix3d::Identity()*Psi_tmp(0,0), Eigen::Matrix3d::Identity()*Psi_tmp(0,1),
+        Eigen::Matrix3d::Identity()*Psi_tmp(1,0), Eigen::Matrix3d::Identity()*Psi_tmp(1,1);
     // get lambda and psi using Eq. (5.23) in the paper
     auto tpvk = TimestampedPoseVelocity<Point3>(p0_p3, v0_p3, 0.0);
     auto tpvkp1 = TimestampedPoseVelocity<Point3>(p1_p3, v1_p3, timestep);

--- a/gtsam/nonlinear/tests/testInterpolator.cpp
+++ b/gtsam/nonlinear/tests/testInterpolator.cpp
@@ -793,14 +793,10 @@ TEST(Interpolator, LambdaPsiConsistencyP2) {
   Interpolator<Point2> interpolator(Q_p2);
   for (double ratio = 0.1; ratio <= 0.9; ratio += 0.1) {
     // get lambda and psi using Eq. (11.41) in the book
-    auto [Lambda_tmp, Psi_tmp] = interpolator.getLambdaPsi(
+    auto [Lambda_book, Psi_book] = interpolator.getLambdaPsi(
         0.0, timestep, timestep * ratio);
-    Eigen::Matrix<double, 4, 4> Lambda_book, Psi_book;
-    Lambda_book << Eigen::Matrix2d::Identity()*Lambda_tmp(0,0), Eigen::Matrix2d::Identity()*Lambda_tmp(0,1),
-        Eigen::Matrix2d::Identity()*Lambda_tmp(1,0), Eigen::Matrix2d::Identity()*Lambda_tmp(1,1);
-    Psi_book << Eigen::Matrix2d::Identity()*Psi_tmp(0,0), Eigen::Matrix2d::Identity()*Psi_tmp(0,1),
-        Eigen::Matrix2d::Identity()*Psi_tmp(1,0), Eigen::Matrix2d::Identity()*Psi_tmp(1,1);
-    // get lambda and psi using Eq. (5.23) in the paper
+    
+        // get lambda and psi using Eq. (5.23) in the paper
     auto tpvk = TimestampedPoseVelocity<Point2>(p0_p2, v0_p2, 0.0);
     auto tpvkp1 = TimestampedPoseVelocity<Point2>(p1_p2, v1_p2, timestep);
     auto pvtau = interpolator.interpolatePoseAndVelocity(
@@ -819,14 +815,9 @@ TEST(Interpolator, LambdaPsiConsistencyP3) {
   Interpolator<Point3> interpolator(Q_p3);
   for (double ratio = 0.1; ratio <= 0.9; ratio += 0.1) {
     // get lambda and psi using Eq. (11.41) in the book
-    auto [Lambda_tmp, Psi_tmp] = interpolator.getLambdaPsi(
+    auto [Lambda_book, Psi_book] = interpolator.getLambdaPsi(
         0.0, timestep, timestep * ratio);
     
-    Eigen::Matrix<double, 6, 6> Lambda_book, Psi_book;
-    Lambda_book << Eigen::Matrix3d::Identity()*Lambda_tmp(0,0), Eigen::Matrix3d::Identity()*Lambda_tmp(0,1),
-        Eigen::Matrix3d::Identity()*Lambda_tmp(1,0), Eigen::Matrix3d::Identity()*Lambda_tmp(1,1);
-    Psi_book << Eigen::Matrix3d::Identity()*Psi_tmp(0,0), Eigen::Matrix3d::Identity()*Psi_tmp(0,1),
-        Eigen::Matrix3d::Identity()*Psi_tmp(1,0), Eigen::Matrix3d::Identity()*Psi_tmp(1,1);
     // get lambda and psi using Eq. (5.23) in the paper
     auto tpvk = TimestampedPoseVelocity<Point3>(p0_p3, v0_p3, 0.0);
     auto tpvkp1 = TimestampedPoseVelocity<Point3>(p1_p3, v1_p3, timestep);


### PR DESCRIPTION
- For WNOA, Lambda and Psi have particularly sparse forms that can be computed more efficiently
- Equation 3.241 in the book shows that Lambda and Psi each are 2x2-block matrix, where each block is a diagonal multiplied by a constant
- Changing the implementation to just compute these constant, which should be cheaper than computing Lambda and Psi through the previous matrix products