### PR TITLE
Slightly faster interp covariance

### DIFF
--- a/gtsam/nonlinear/Interpolator.cpp
+++ b/gtsam/nonlinear/Interpolator.cpp
@@ -301,13 +301,13 @@ Interpolator<PoseType>::computeJointMarginals(
   // Lambda function for forming the boundary key vector
   auto formBoundaryKeyVector = [](const StateDataInterval& stateDataBorders) {
     KeyVector boundaryKeyVector;
-    if (stateDataBorders.lower.has_value()) {
-      boundaryKeyVector.push_back(stateDataBorders.lower->pose); // p1
-      boundaryKeyVector.push_back(stateDataBorders.lower->vel); // v1
+    if (stateDataBorders.first.has_value()) {
+      boundaryKeyVector.push_back(stateDataBorders.first->pose); // p1
+      boundaryKeyVector.push_back(stateDataBorders.first->vel); // v1
     }
-    if (stateDataBorders.upper.has_value()) {
-      boundaryKeyVector.push_back(stateDataBorders.upper->pose); // p2
-      boundaryKeyVector.push_back(stateDataBorders.upper->vel); // v2
+    if (stateDataBorders.second.has_value()) {
+      boundaryKeyVector.push_back(stateDataBorders.second->pose); // p2
+      boundaryKeyVector.push_back(stateDataBorders.second->vel); // v2
     }
     return boundaryKeyVector;
   };
@@ -364,8 +364,8 @@ Values Interpolator<PoseType>::interpolatePosesAndVelocities(
     for (const auto& stateDataInterp : interpolatedStates) {
       auto it2 = mainSolveStates.upper_bound(stateDataInterp);
       StateDataInterval interval;
-      interval.lower = it2 == mainSolveStates.begin() ? std::nullopt : std::optional<StateData>(*std::prev(it2));
-      interval.upper = it2 == mainSolveStates.end() ? std::nullopt : std::optional<StateData>(*it2);
+      interval.first = it2 == mainSolveStates.begin() ? std::nullopt : std::optional<StateData>(*std::prev(it2));
+      interval.second = it2 == mainSolveStates.end() ? std::nullopt : std::optional<StateData>(*it2);
       queryBuckets[interval].push_back(stateDataInterp);
     }
 
@@ -394,8 +394,8 @@ Values Interpolator<PoseType>::interpolatePosesAndVelocities(
       };
       
       // Get the poses and velocities at t_k and t_kp1
-      std::optional<TimestampedPoseVel> pvk  = makeTimestampedPV(stateDataBorder.lower);
-      std::optional<TimestampedPoseVel> pvkp1 = makeTimestampedPV(stateDataBorder.upper);
+      std::optional<TimestampedPoseVel> pvk  = makeTimestampedPV(stateDataBorder.first);
+      std::optional<TimestampedPoseVel> pvkp1 = makeTimestampedPV(stateDataBorder.second);
       Matrix covarianceOut;                             // (2*dim, 2*dim)
 
       // Interpolate for all query times within this query interval (bucket)

--- a/gtsam/nonlinear/Interpolator.cpp
+++ b/gtsam/nonlinear/Interpolator.cpp
@@ -36,20 +36,74 @@ Interpolator<PoseType>::Interpolator(const VectorN& Q_psd)
 // ---- Member Functions ----
 template <typename PoseType>
 typename Interpolator<PoseType>::PoseVel
+Interpolator<PoseType>::extrapolatePoseAndVelocity(
+    const std::optional<TimestampedPoseVel>& tPoseVel_k,
+    const std::optional<TimestampedPoseVel>& tPoseVel_kp1,
+    double t_tau,
+    OptionalMatrixVecType H,
+    const std::shared_ptr<Matrix>& mainSolveMarginalMatrix,
+    Matrix* covarianceOut) const {
+  
+  auto poseVel_ex =
+      (!tPoseVel_kp1.has_value() || t_tau < tPoseVel_k.value().timestamp)
+      ? tPoseVel_k.value().poseVel : tPoseVel_kp1.value().poseVel;
+  double t_diff;
+  if (!tPoseVel_kp1.has_value() || t_tau < tPoseVel_k.value().timestamp) { // lower than the earliest time
+    t_diff = t_tau - tPoseVel_k.value().timestamp;
+  } else if (!tPoseVel_k.has_value() || t_tau > tPoseVel_kp1.value().timestamp) { // greater than the latest time
+    t_diff = t_tau - tPoseVel_kp1.value().timestamp;
+  } else {  // shouldn't happen if this function is called
+    throw std::runtime_error(
+        "Unexpected case in extrapolatePoseAndVelocity");
+  }
+  // follow (11.5) in the book
+  auto [T_ex, varpi_ex] = poseVel_ex;
+  Vector2N gamma_k;
+  gamma_k.topRows(dim).setZero();
+  gamma_k.bottomRows(dim) = varpi_ex;
+  auto Psi = transitionFunction_(t_diff);
+  auto gamma_ex = Psi * gamma_k;
+  auto T_tau = traits<PoseType>::Compose(
+      T_ex, traits<PoseType>::Expmap(gamma_ex.topRows(dim), nullptr));
+  auto varpi_tau = gamma_ex.bottomRows(dim);
+
+  if (mainSolveMarginalMatrix) {
+    // compute covariance of the extrapolated pose and velocity
+    // assume that mainSolveMarginalMatrix corresponds to the covariance of
+    // Tvarpi_extrapolate_point
+    assert(mainSolveMarginalMatrix->rows() == 2 * dim &&
+            mainSolveMarginalMatrix->cols() == 2 * dim);
+    Matrix2N Sigma = covarianceFunction_(t_diff, Q_psd_);
+    // (11.5) in the book
+    *covarianceOut =
+        Sigma + Psi * *mainSolveMarginalMatrix * Psi.transpose();
+  }
+  return PoseVel{T_tau, varpi_tau};
+}
+
+template <typename PoseType>
+typename Interpolator<PoseType>::PoseVel
 Interpolator<PoseType>::interpolatePoseAndVelocity(
-    const TimestampedPoseVel& tPoseVel_k,
-    const TimestampedPoseVel& tPoseVel_kp1,
+    const std::optional<TimestampedPoseVel>& tPoseVel_k,
+    const std::optional<TimestampedPoseVel>& tPoseVel_kp1,
     double t_tau,
     OptionalMatrixVecType H,
     const std::shared_ptr<Matrix>& mainSolveMarginalMatrix,
     Matrix* covarianceOut) const {
 
-    // unpack inputs
-    auto [poseVel_k, t_k] = tPoseVel_k;
-    auto [T_k, varpi_k] = poseVel_k;
-    auto [poseVel_kp1, t_kp1] = tPoseVel_kp1;
-    auto [T_kp1, varpi_kp1] = poseVel_kp1;
+    // extrapolate if t_tau is outside the range
+    if (!tPoseVel_k.has_value() || !tPoseVel_kp1.has_value() ||
+     t_tau < tPoseVel_k.value().timestamp || t_tau > tPoseVel_kp1.value().timestamp) {
+      return extrapolatePoseAndVelocity(
+          tPoseVel_k, tPoseVel_kp1, t_tau, H, mainSolveMarginalMatrix, covarianceOut);
+    }
 
+    // unpack inputs
+    auto [poseVel_k, t_k] = tPoseVel_k.value();
+    auto [T_k, varpi_k] = poseVel_k;
+    auto [poseVel_kp1, t_kp1] = tPoseVel_kp1.value();
+    auto [T_kp1, varpi_kp1] = poseVel_kp1;
+    
     // if t_tau is equal to t_k or t_kp1, return the corresponding pose and
     // velocity
     if (equal(t_tau, t_k)) {
@@ -104,43 +158,6 @@ Interpolator<PoseType>::interpolatePoseAndVelocity(
         *covarianceOut = mainSolveMarginalMatrix->bottomRightCorner(dim*2, dim*2);
       }
       return poseVel_kp1;
-
-    } else if (t_tau < t_k || t_tau > t_kp1 || std::isinf(t_k) ||
-               std::isinf(t_kp1)) {
-      auto poseVel_ex =
-          (t_tau < t_k || std::isinf(t_kp1)) ? poseVel_k : poseVel_kp1;
-      double t_diff;
-      if (t_tau < t_k || std::isinf(t_kp1)) {
-        t_diff = t_tau - t_k;
-      } else if (t_tau > t_kp1 || std::isinf(t_k)) {
-        t_diff = t_tau - t_kp1;
-      } else {  // shouldn't happen unless this code is bugged
-        throw std::runtime_error(
-            "Unexpected case in interpolatePoseAndVelocity");
-      }
-      // follow (11.5) in the book
-      auto [T_ex, varpi_ex] = poseVel_ex;
-      Vector2N gamma_k;
-      gamma_k.topRows(dim).setZero();
-      gamma_k.bottomRows(dim) = varpi_ex;
-      auto Psi = transitionFunction_(t_diff);
-      auto gamma_ex = Psi * gamma_k;
-      auto T_tau = traits<PoseType>::Compose(
-          T_ex, traits<PoseType>::Expmap(gamma_ex.topRows(dim), nullptr));
-      auto varpi_tau = gamma_ex.bottomRows(dim);
-
-      if (mainSolveMarginalMatrix) {
-        // compute covariance of the extrapolated pose and velocity
-        // assume that mainSolveMarginalMatrix corresponds to the covariance of
-        // Tvarpi_extrapolate_point
-        assert(mainSolveMarginalMatrix->rows() == 2 * dim &&
-               mainSolveMarginalMatrix->cols() == 2 * dim);
-        Matrix2N Sigma = covarianceFunction_(t_diff, Q_psd_);
-        // (11.5) in the book
-        *covarianceOut =
-            Sigma + Psi * *mainSolveMarginalMatrix * Psi.transpose();
-      }
-      return PoseVel{T_tau, varpi_tau};
 
     } else {
 
@@ -263,12 +280,49 @@ Interpolator<PoseType>::interpolatePoseAndVelocity(
         // LambdaPsi << Lambda_paper, Psi_paper;
 
         // use existing Lambda and Psi computed from (11.41) in the book
-        Matrix2N Sigma = computeConditionalCov(tPoseVel_k, tPoseVel_kp1, TimestampedPoseVel{poseVel_tau, t_tau});
+        Matrix2N Sigma = computeConditionalCov(tPoseVel_k.value(), tPoseVel_kp1.value(), TimestampedPoseVel{poseVel_tau, t_tau});
         LambdaPsi <<  Lambda, Psi;
         *covarianceOut = Sigma + LambdaPsi * *mainSolveMarginalMatrix * LambdaPsi.transpose();
       }
       return poseVel_tau;
     }
+}
+
+template <typename PoseType>
+std::map<StateDataInterval, std::shared_ptr<Matrix>>
+Interpolator<PoseType>::computeJointMarginals(
+    const std::map<StateDataInterval, std::vector<StateData>>& queryBuckets,
+    const std::unique_ptr<Marginals>& marginals) {
+  std::map<StateDataInterval, std::shared_ptr<Matrix>>
+    intervalJointMarginals;  // JointMarginal matrices for each interval
+  std::unordered_set<Key> allBoundaryKeys;
+  for (const auto& [stateDataBorders, stateDataInterpVec] : queryBuckets) {
+    
+    // Compute covariances of the interpolated poses and velocities
+    // following (5.22) in paper
+    KeyVector boundaryKeyVector;
+    if (stateDataBorders.lower.has_value()) {
+      boundaryKeyVector.push_back(stateDataBorders.lower->pose); // p1
+      boundaryKeyVector.push_back(stateDataBorders.lower->vel); // v1
+    }
+    if (stateDataBorders.upper.has_value()) {
+      boundaryKeyVector.push_back(stateDataBorders.upper->pose); // p2
+      boundaryKeyVector.push_back(stateDataBorders.upper->vel); // v2
+    }
+    allBoundaryKeys.insert(boundaryKeyVector.begin(), boundaryKeyVector.end());
+
+    // Method 1: compute JointMarginal for each interval separately
+    JointMarginal mainSolveMarginal =
+    marginals->jointMarginalCovariance(boundaryKeyVector);
+    // avoid using JointMarginal.fullMatrix() as it returns covariance
+    // in alphabetical order of the keys...
+    auto mainSolveMarginalMatrix =
+      std::make_shared<Matrix>(constructMatrixFromJointMarginal(
+      mainSolveMarginal, boundaryKeyVector, dim));
+    intervalJointMarginals[stateDataBorders] = mainSolveMarginalMatrix;
+  }
+
+  return intervalJointMarginals;
 }
 
 template <typename PoseType>
@@ -279,77 +333,50 @@ Values Interpolator<PoseType>::interpolatePosesAndVelocities(
     std::shared_ptr<CovarianceMap> covarianceMapOut) const {
 
     // Map from intervals [t1, t2) to query times inside that interval (bucket)
-    std::map<std::pair<StateData, StateData>, std::vector<StateData>> queryBuckets;
+    std::map<StateDataInterval, std::vector<StateData>> queryBuckets;
 
     for (const auto& stateDataInterp : interpolatedStates) {
       auto it2 = mainSolveStates.upper_bound(stateDataInterp);
-      if(it2 == mainSolveStates.end()) {
-        auto it1 = std::prev(it2);
-        queryBuckets[std::make_pair(*it1, StateData::PosInf)].push_back(stateDataInterp);
-      }
-      else if(it2 == mainSolveStates.begin()) {
-        queryBuckets[std::make_pair(StateData::NegInf, *it2)].push_back(stateDataInterp);
-      }
-      else {
-        auto it1 = std::prev(it2);
-        queryBuckets[std::make_pair(*it1, *it2)].push_back(stateDataInterp);
-      }
+      StateDataInterval interval;
+      interval.lower = it2 == mainSolveStates.begin() ? std::nullopt : std::optional<StateData>(*std::prev(it2));
+      interval.upper = it2 == mainSolveStates.end() ? std::nullopt : std::optional<StateData>(*it2);
+      queryBuckets[interval].push_back(stateDataInterp);
     }
 
     Values interpolatedSolution;
 
-    std::unique_ptr<Marginals>
-        marginals;  // Only construct a Marginals if requested
+    std::unique_ptr<Marginals> marginals;  // Only construct a Marginals if requested
+    auto intervalJointMarginals = std::map<StateDataInterval, std::shared_ptr<Matrix>>(); // JointMarginal matrices for each interval
+    // Get the marginals for the boundary states
     if (covarianceMapOut) {
-      marginals =
-          std::make_unique<Marginals>(mainSolveGraph, mainSolveSolution);
+      marginals = std::make_unique<Marginals>(mainSolveGraph, mainSolveSolution);
+      intervalJointMarginals = computeJointMarginals(queryBuckets, marginals);
     }
-    for (const auto& [stateDataBorders, stateDataInterpVec] : queryBuckets) {
-      StateData state1 = stateDataBorders.first;
-      StateData state2 = stateDataBorders.second;
 
+    for (const auto& [stateDataBorder, stateDataInterpVec] : queryBuckets) {
+
+      auto makeTimestampedPV = [&](const std::optional<StateData>& s)
+          -> std::optional<TimestampedPoseVel> {
+        if (!s) return std::nullopt;
+        return TimestampedPoseVel(
+            mainSolveSolution.at<PoseType>(s->pose),
+            mainSolveSolution.at<VelocityType>(s->vel),
+            s->time
+        );
+      };
+      
       // Get the poses and velocities at t_k and t_kp1
-      auto pvk = state1.isInfTime()
-                     ? TimestampedPoseVel(PoseVel(), state1.time)
-                     : TimestampedPoseVel(mainSolveSolution.at<PoseType>(
-                                              state1.pose),
-                                          mainSolveSolution.at<VelocityType>(
-                                              state1.vel),
-                                          state1.time);
-      auto pvkp1 = state2.isInfTime()
-                       ? TimestampedPoseVel(PoseVel(), state2.time)
-                       : TimestampedPoseVel(mainSolveSolution.at<PoseType>(
-                                               state2.pose),
-                                            mainSolveSolution.at<VelocityType>(
-                                                state2.vel),
-                                            state2.time);
-
-      // Compute covariances of the interpolated poses and velocities
-      std::shared_ptr<Matrix> mainSolveMarginalMatrix;  // (4*dim, 4*dim)
+      std::optional<TimestampedPoseVel> pvk  = makeTimestampedPV(stateDataBorder.lower);
+      std::optional<TimestampedPoseVel> pvkp1 = makeTimestampedPV(stateDataBorder.upper);
       Matrix covarianceOut;                             // (2*dim, 2*dim)
-      if (covarianceMapOut) {
-        // following (5.22) in paper
-        KeyVector variables;
-        if (state1.isInfTime()) {
-          variables = {state2.pose, state2.vel};  // {p2, v2}
-        } else if (state2.isInfTime()) {
-          variables = {state1.pose, state1.vel};  // {p1, v1}
-        } else {
-          variables = {
-              // {p1, v1, p2, v2}
-              state1.pose, state1.vel, state2.pose, state2.vel};
-        }
-        JointMarginal mainSolveMarginal =
-            marginals->jointMarginalCovariance(variables);
-        // avoid using JointMarginal.fullMatrix() as it returns covariance
-        // in alphabetical order of the keys...
-        mainSolveMarginalMatrix =
-            std::make_shared<Matrix>(constructMatrixFromJointMarginal(
-                mainSolveMarginal, variables, dim));
-      }
 
       // Interpolate for all query times within this query interval (bucket)
-      for (auto stateDataInterp : stateDataInterpVec) {
+      for (const auto& stateDataInterp : stateDataInterpVec) {
+        std::shared_ptr<Matrix> mainSolveMarginalMatrix;  // (4*dim, 4*dim)
+        if (covarianceMapOut) {
+          mainSolveMarginalMatrix =
+              intervalJointMarginals[stateDataBorder];
+        }
         auto pvtau =
             interpolatePoseAndVelocity(pvk, pvkp1, stateDataInterp.time, nullptr,
                                        mainSolveMarginalMatrix, &covarianceOut);
@@ -439,7 +466,6 @@ Interpolator<PoseType>::computeConditionalCov(
     OptionalMatrixType Lambda,
     OptionalMatrixType Psi) const {
     
-    // unpacking then repacking... maybe this can be written better
     auto [poseVel_k, t_k] = tPoseVel_k;
     auto [poseVel_kp1, t_kp1] = tPoseVel_kp1;
     auto [poseVel_tau, t_tau] = tPoseVel_tau;

--- a/gtsam/nonlinear/Interpolator.cpp
+++ b/gtsam/nonlinear/Interpolator.cpp
@@ -293,13 +293,13 @@ std::map<StateDataInterval, std::shared_ptr<Matrix>>
 Interpolator<PoseType>::computeJointMarginals(
     const std::map<StateDataInterval, std::vector<StateData>>& queryBuckets,
     const std::unique_ptr<Marginals>& marginals) {
+  std::cout << "Computing joint marginals for " << queryBuckets.size() << " intervals." << std::endl;
   std::map<StateDataInterval, std::shared_ptr<Matrix>>
     intervalJointMarginals;  // JointMarginal matrices for each interval
   std::unordered_set<Key> allBoundaryKeys;
-  for (const auto& [stateDataBorders, stateDataInterpVec] : queryBuckets) {
-    
-    // Compute covariances of the interpolated poses and velocities
-    // following (5.22) in paper
+
+  // Lambda function for forming the boundary key vector
+  auto formBoundaryKeyVector = [](const StateDataInterval& stateDataBorders) {
     KeyVector boundaryKeyVector;
     if (stateDataBorders.lower.has_value()) {
       boundaryKeyVector.push_back(stateDataBorders.lower->pose); // p1
@@ -309,19 +309,44 @@ Interpolator<PoseType>::computeJointMarginals(
       boundaryKeyVector.push_back(stateDataBorders.upper->pose); // p2
       boundaryKeyVector.push_back(stateDataBorders.upper->vel); // v2
     }
+    return boundaryKeyVector;
+  };
+
+  for (const auto& [stateDataBorders, stateDataInterpVec] : queryBuckets) {
+    KeyVector boundaryKeyVector = formBoundaryKeyVector(stateDataBorders);
     allBoundaryKeys.insert(boundaryKeyVector.begin(), boundaryKeyVector.end());
 
     // Method 1: compute JointMarginal for each interval separately
-    JointMarginal mainSolveMarginal =
-    marginals->jointMarginalCovariance(boundaryKeyVector);
-    // avoid using JointMarginal.fullMatrix() as it returns covariance
-    // in alphabetical order of the keys...
-    auto mainSolveMarginalMatrix =
-      std::make_shared<Matrix>(constructMatrixFromJointMarginal(
-      mainSolveMarginal, boundaryKeyVector, dim));
-    intervalJointMarginals[stateDataBorders] = mainSolveMarginalMatrix;
+    // faster if there are not too many intervals
+    // ----------------------------------
+    // JointMarginal mainSolveMarginal =
+    // marginals->jointMarginalCovariance(boundaryKeyVector);
+    // // avoid using JointMarginal.fullMatrix() as it returns covariance
+    // // in alphabetical order of the keys...
+    // auto mainSolveMarginalMatrix =
+    //   std::make_shared<Matrix>(constructMatrixFromJointMarginal(
+    //   mainSolveMarginal, boundaryKeyVector, dim));
+    // intervalJointMarginals[stateDataBorders] = mainSolveMarginalMatrix;
+    // ----------------------------------
   }
 
+  // Method 2: compute JointMarginal for all boundary keys at once
+  // faster if there are many intervals with shared boundary keys
+  // ----------------------------------
+  JointMarginal allBoundaryMarginal =
+      marginals->jointMarginalCovariance(
+          KeyVector(allBoundaryKeys.begin(), allBoundaryKeys.end()));
+  
+  for (const auto& [stateDataBorders, stateDataInterpVec] : queryBuckets) {
+    KeyVector boundaryKeyVector = formBoundaryKeyVector(stateDataBorders);
+    auto mainSolveMarginalMatrix =
+      std::make_shared<Matrix>(constructMatrixFromJointMarginal(
+      allBoundaryMarginal, boundaryKeyVector, dim));
+    intervalJointMarginals[stateDataBorders] = mainSolveMarginalMatrix;
+  }
+  // ----------------------------------
+
+  std::cout << "Computed joint marginals for " << intervalJointMarginals.size() << " intervals." << std::endl;
   return intervalJointMarginals;
 }
 

--- a/gtsam/nonlinear/Interpolator.cpp
+++ b/gtsam/nonlinear/Interpolator.cpp
@@ -335,6 +335,7 @@ Values Interpolator<PoseType>::interpolatePosesAndVelocities(
     // Map from intervals [t1, t2) to query times inside that interval (bucket)
     std::map<StateDataInterval, std::vector<StateData>> queryBuckets;
 
+    // Find all intervals [t_k, t_kp1) that contain at least one query time
     for (const auto& stateDataInterp : interpolatedStates) {
       auto it2 = mainSolveStates.upper_bound(stateDataInterp);
       StateDataInterval interval;
@@ -345,14 +346,16 @@ Values Interpolator<PoseType>::interpolatePosesAndVelocities(
 
     Values interpolatedSolution;
 
-    std::unique_ptr<Marginals> marginals;  // Only construct a Marginals if requested
-    auto intervalJointMarginals = std::map<StateDataInterval, std::shared_ptr<Matrix>>(); // JointMarginal matrices for each interval
-    // Get the marginals for the boundary states
+    std::unique_ptr<Marginals> fullMarginal;  // Only construct a Marginals if requested
+    // JointMarginal matrices for each interval (every pair of boundary states involved)
+    auto intervalJointMarginals = std::map<StateDataInterval, std::shared_ptr<Matrix>>();
     if (covarianceMapOut) {
-      marginals = std::make_unique<Marginals>(mainSolveGraph, mainSolveSolution);
-      intervalJointMarginals = computeJointMarginals(queryBuckets, marginals);
+      // Compute all required joint marginals
+      fullMarginal = std::make_unique<Marginals>(mainSolveGraph, mainSolveSolution);
+      intervalJointMarginals = computeJointMarginals(queryBuckets, fullMarginal);
     }
 
+    // Perform interpolation for each bucket
     for (const auto& [stateDataBorder, stateDataInterpVec] : queryBuckets) {
 
       auto makeTimestampedPV = [&](const std::optional<StateData>& s)

--- a/gtsam/nonlinear/Interpolator.h
+++ b/gtsam/nonlinear/Interpolator.h
@@ -66,16 +66,9 @@ using gtsam::tictoc_print_;
 
 namespace gtsam {
 
-// Struct for intervals of boundary states
-struct StateDataInterval {  // maybe move this to StateData.h
-  std::optional<StateData> lower;  // empty = -inf
-  std::optional<StateData> upper;  // empty = +inf
-
-  bool operator<(const StateDataInterval& other) const {
-    if (!(lower == other.lower)) return lower < other.lower;
-    return upper < other.upper;
-  }
-};
+// Intervals of boundary states
+// empty optional = unbounded
+using StateDataInterval = std::pair<std::optional<StateData>, std::optional<StateData>>;
 
 template <typename PoseType>
 struct PoseVelocity {

--- a/gtsam/nonlinear/Interpolator.h
+++ b/gtsam/nonlinear/Interpolator.h
@@ -62,8 +62,20 @@ using gtsam::tictoc_print_;
 #include <string>
 #include <utility>
 #include <vector>
+#include <unordered_set>
 
 namespace gtsam {
+
+// Struct for intervals of boundary states
+struct StateDataInterval {  // maybe move this to StateData.h
+  std::optional<StateData> lower;  // empty = -inf
+  std::optional<StateData> upper;  // empty = +inf
+
+  bool operator<(const StateDataInterval& other) const {
+    if (!(lower == other.lower)) return lower < other.lower;
+    return upper < other.upper;
+  }
+};
 
 template <typename PoseType>
 struct PoseVelocity {
@@ -133,9 +145,17 @@ class Interpolator {
   // Default to WNOA
   Interpolator(const VectorN& Q_psd);
 
+  PoseVel extrapolatePoseAndVelocity(
+      const std::optional<TimestampedPoseVel>& Tvarpi_k,
+      const std::optional<TimestampedPoseVel>& Tvarpi_kp1,
+      double t_tau,
+      OptionalMatrixVecType H = nullptr,
+      const std::shared_ptr<Matrix>& mainSolveMarginalMatrix = nullptr,
+      Matrix* covarianceOut = nullptr) const;
+
   PoseVel interpolatePoseAndVelocity(
-      const TimestampedPoseVel& Tvarpi_k,
-      const TimestampedPoseVel& Tvarpi_kp1,
+      const std::optional<TimestampedPoseVel>& Tvarpi_k,
+      const std::optional<TimestampedPoseVel>& Tvarpi_kp1,
       double t_tau,
       OptionalMatrixVecType H = nullptr,
       const std::shared_ptr<Matrix>& mainSolveMarginalMatrix = nullptr,
@@ -161,6 +181,11 @@ class Interpolator {
                                  OptionalMatrixType Psi = nullptr) const;
 
  protected:
+  static std::map<StateDataInterval, std::shared_ptr<Matrix>>
+  computeJointMarginals(
+    const std::map<StateDataInterval, std::vector<StateData>>& queryBuckets,
+    const std::unique_ptr<Marginals>& marginals);
+
   // construct the full covariance matrix using the order given by keyVector
   static Matrix constructMatrixFromJointMarginal(const JointMarginal& blockMatrix,
                                                  const KeyVector& keyVector,

--- a/gtsam/nonlinear/StateData.h
+++ b/gtsam/nonlinear/StateData.h
@@ -19,9 +19,6 @@ struct StateData {
   StateData(Key pose_in, Key vel_in, double time_in)
       : pose(pose_in), vel(vel_in), time(time_in) {};
 
-  static const StateData PosInf;
-  static const StateData NegInf;
-
   // Less than operator to enable sorting
   bool operator<(const StateData& other) const {
     return this->time < other.time;
@@ -46,15 +43,7 @@ struct StateData {
     }
     return false;
   }
-
-  bool isInfTime() const {
-    return std::isinf(this->time);
-  }
 };
-
-// dummy states used for identifying states to be extrapolated in the Interpolator
-const StateData StateData::PosInf(0, 0, std::numeric_limits<double>::infinity());
-const StateData StateData::NegInf(0, 0, -std::numeric_limits<double>::infinity());
 
 }  // namespace gtsam
 


### PR DESCRIPTION
Instead of getting the joint covariance for every interval, it calls JointMarginalCovariance for all required boundary states. This requires one big inversion, but it's still faster than calling JointMarginalCovariance for every interval.

Also refactored Interpolator a bit. Notably:
- Previously had a dummy StateData with infinite time to represent an open boundary, i.e. we are extrapolating... that was very hacky
- Instead, it was replaced with std::optional, so that an empty value corresponds to an open boundary