### PR TITLE
WNOA interpolator cleanup: 5 review commits

### DIFF
--- a/gtsam/nonlinear/WNOAFactor.h
+++ b/gtsam/nonlinear/WNOAFactor.h
@@ -326,7 +326,7 @@ class WNOAMotionFactor
    * @param deltaT Time interval
    * @return Matrix2N Transition matrix
    */
-  static Matrix2N transitionFunction(double deltaT) {
+  static Matrix2N TransitionFunction(double deltaT) {
     // Construct the transition matrix for the WNOA factor
     Matrix2N F;
     F << kIdentity, deltaT * kIdentity, kZero, kIdentity;
@@ -346,7 +346,7 @@ class WNOAMotionFactor
    * @param deltaT Time interval
    * @return Matrix2N Jacobian block w.r.t. previous state
    */
-  static Matrix2N computeJacobianPrev(const std::pair<Pose, Velocity>& pv1,
+  static Matrix2N ComputeJacobianPrev(const std::pair<Pose, Velocity>& pv1,
                                       const std::pair<Pose, Velocity>& pv2,
                                       double deltaT) {
     // corresponds to F in (11.20) in SER
@@ -379,7 +379,7 @@ class WNOAMotionFactor
    * @param deltaT Time interval
    * @return Matrix2N Jacobian block w.r.t. next state
    */
-  static Matrix2N computeJacobianNext(const std::pair<Pose, Velocity>& pv1,
+  static Matrix2N ComputeJacobianNext(const std::pair<Pose, Velocity>& pv1,
                                       const std::pair<Pose, Velocity>& pv2,
                                       double deltaT) {
     // corresponds to E in (11.21) in SER

--- a/gtsam/nonlinear/WNOAFactor.h
+++ b/gtsam/nonlinear/WNOAFactor.h
@@ -78,8 +78,8 @@ class WNOAMotionFactor
   using MatrixNx2N = Eigen::Matrix<double, dim, 2 * dim>;
   typedef NoiseModelFactorN<Pose, Velocity, Pose, Velocity> Base;
   typedef WNOAMotionFactor This;
-  // Time between the two states
-  double deltaT_;
+
+  double deltaT_;  ///< Time between the two states
 
   inline static const MatrixN kIdentity = MatrixN::Identity();
   inline static const MatrixN kZero = MatrixN::Zero();
@@ -101,40 +101,21 @@ class WNOAMotionFactor
    * @param dxi_dT2 Optional output dxi/dT2
    * @param dvErr_dxi Optional output d(velocity error)/dxi
    */
-  static void computeRelativePose(const Pose& p1, const Pose& p2,
-                                   const Velocity& v2, VectorN* xi,
-                                   MatrixN* invJr, MatrixN* dxi_dT1,
-                                   MatrixN* dxi_dT2, MatrixN* dvErr_dxi) {
-    assert(xi && "Output xi pointer must be valid");
-    assert(invJr && "Output invJr pointer must be valid");
-
-    const bool compute_dxi_dT1 = (dxi_dT1 != nullptr);
-    const bool compute_dxi_dT2 = (dxi_dT2 != nullptr);
-    const bool compute_dvErr_dxi = (dvErr_dxi != nullptr);
-
+  static void ComputeRelativePose(const Pose& p1, const Pose& p2,
+                                  const Velocity& v2, VectorN& xi,
+                                  MatrixN& invJr, MatrixN* dxi_dT1,
+                                  MatrixN* dxi_dT2, MatrixN* dvErr_dxi) {
     // Local variable for the relative pose in the tangent space
     // Note that p1 = T(t_k), p2 = T(t_{k+1})
     // compute xi = log(T_k^-1 T_{k+1})^check
-    if (compute_dxi_dT1 || compute_dxi_dT2) {
-      MatrixN dbetween_p1;
-      MatrixN dbetween_p2;
-      *xi = traits<Pose>::Logmap(
-          traits<Pose>::Between(p1, p2,
-                                compute_dxi_dT1 ? &dbetween_p1 : nullptr,
-                                compute_dxi_dT2 ? &dbetween_p2 : nullptr),
-          invJr);
-      if (compute_dxi_dT1) {
-        *dxi_dT1 = (*invJr) * dbetween_p1;
-      }
-      if (compute_dxi_dT2) {
-        *dxi_dT2 = (*invJr) * dbetween_p2;
-      }
-    } else {
-      *xi = traits<Pose>::Logmap(traits<Pose>::Between(p1, p2), invJr);
-    }
+    MatrixN dBetween_p1;
+    auto p12 = traits<Pose>::Between(p1, p2, dxi_dT1 ? &dBetween_p1 : nullptr);
+    xi = traits<Pose>::Logmap(p12, &invJr);
+    if (dxi_dT1) *dxi_dT1 = invJr * dBetween_p1;
+    if (dxi_dT2) *dxi_dT2 = invJr;
 
     // Derivative of velocity error wrt xi
-    if (compute_dvErr_dxi) {
+    if (dvErr_dxi) {
       // Zero for vector spaces, use an approximation for Lie groups
       if constexpr (std::is_same_v<typename traits<Pose>::structure_category,
                                    vector_space_tag>) {
@@ -142,9 +123,9 @@ class WNOAMotionFactor
       } else {
         // For Lie groups
         auto ad_v2 = Pose::adjointMap(v2);
-        auto ad_xi = Pose::adjointMap(*xi);
+        auto ad_xi = Pose::adjointMap(xi);
         *dvErr_dxi = -ad_v2 / 2.0 -
-              (Pose::adjointMap(ad_xi * v2) + ad_xi * ad_v2) / 12.0;
+                     (Pose::adjointMap(ad_xi * v2) + ad_xi * ad_v2) / 12.0;
       }
     }
   }
@@ -177,7 +158,7 @@ class WNOAMotionFactor
     assert(this->deltaT_ > 0.0 &&
            "Time difference between input states must be positive.");
     // define noise model
-    this->noiseModel_ = This::buildWNOANoiseModel(this->deltaT_, q_psd_diag);
+    this->noiseModel_ = BuildWNOANoiseModel(this->deltaT_, q_psd_diag);
   }
 
   /**
@@ -192,7 +173,7 @@ class WNOAMotionFactor
    */
   WNOAMotionFactor(Key poseKey0, Key velKey0, Key poseKey1, Key velKey1,
                    const double deltaT, const VectorN& q_psd_diag)
-      : Base(This::buildWNOANoiseModel(deltaT, q_psd_diag), poseKey0, velKey0,
+      : Base(BuildWNOANoiseModel(deltaT, q_psd_diag), poseKey0, velKey0,
              poseKey1, velKey1),
         deltaT_(deltaT) {}
 
@@ -204,10 +185,9 @@ class WNOAMotionFactor
   void print(
       const std::string& s = "",
       const KeyFormatter& keyFormatter = DefaultKeyFormatter) const override {
-    std::cout << s << "WNOAMotionFactor(" << keyFormatter(this->key1())
-              << "," << keyFormatter(this->key2()) << ","
-              << keyFormatter(this->key3()) << ","
-              << keyFormatter(this->key4()) << ")\n";
+    std::cout << s << "WNOAMotionFactor(" << keyFormatter(this->key1()) << ","
+              << keyFormatter(this->key2()) << "," << keyFormatter(this->key3())
+              << "," << keyFormatter(this->key4()) << ")\n";
     this->noiseModel_->print("  noise model: ");
   }
 
@@ -247,14 +227,13 @@ class WNOAMotionFactor
     MatrixN dxi_dT2;
     MatrixN dvErr_dxi;
     if (Hp1 || Hp2) {
-      computeRelativePose(p1, p2, v2, &xi, &invJr, &dxi_dT1, &dxi_dT2,
-                           &dvErr_dxi);
+      ComputeRelativePose(p1, p2, v2, xi, invJr, &dxi_dT1, &dxi_dT2,
+                          &dvErr_dxi);
     } else {
-      computeRelativePose(p1, p2, v2, &xi, &invJr, nullptr, nullptr, nullptr);
+      ComputeRelativePose(p1, p2, v2, xi, invJr, nullptr, nullptr, nullptr);
     }
 
-    // Compute error for local state vector (pose, velocity) in the tangent
-    // space
+    // Compute error for local state vector (pose, velocity) in tangent space
     Vector2N err;
     err << xi - deltaT_ * v1, invJr * v2 - v1;
 
@@ -292,14 +271,14 @@ class WNOAMotionFactor
    * @param q_psd_diag Diagonal PSD vector
    * @return Matrix2N Process covariance
    */
-  static Matrix2N buildWNOACovariance(double timestep,
+  static Matrix2N BuildWNOACovariance(double timestep,
                                       const VectorN& q_psd_diag) {
     //
     Matrix2N covariance;
     const MatrixN Q_diag = q_psd_diag.asDiagonal();
     covariance << (1.0 / 3.0 * std::pow(timestep, 3)) * Q_diag,
-        (1.0 / 2.0 * std::pow(timestep, 2)) * Q_diag,
-        (1.0 / 2.0 * pow(timestep, 2)) * Q_diag, timestep * Q_diag;
+        (0.5 * std::pow(timestep, 2)) * Q_diag,
+        (0.5 * pow(timestep, 2)) * Q_diag, timestep * Q_diag;
     return covariance;
   }
 
@@ -310,16 +289,14 @@ class WNOAMotionFactor
    * @param q_psd_diag Diagonal PSD vector
    * @return Matrix2N Inverse process covariance matrix
    */
-  static Matrix2N buildInverseWNOACovariance(double timestep,
+  static Matrix2N BuildInverseWNOACovariance(double dt,
                                              const VectorN& q_psd_diag) {
     // construct the inverse covariance matrix for the WNOA factor
     Matrix2N inverse_covariance;
     const MatrixN Q_inv_diag = q_psd_diag.cwiseInverse().asDiagonal();
-    inverse_covariance << (12.0 / (timestep * timestep * timestep)) *
-                              Q_inv_diag,
-        (-6.0 / (timestep * timestep)) * Q_inv_diag,
-        (-6.0 / (timestep * timestep)) * Q_inv_diag,
-        (4.0 / timestep) * Q_inv_diag;
+    const double dt2 = dt * dt, dt3 = dt2 * dt;
+    inverse_covariance << (12.0 / dt3) * Q_inv_diag, (-6.0 / dt2) * Q_inv_diag,
+        (-6.0 / dt2) * Q_inv_diag, (4.0 / dt) * Q_inv_diag;
 
     return inverse_covariance;
   }
@@ -328,16 +305,16 @@ class WNOAMotionFactor
    * @brief Convenience helper to construct a Gaussian noise model from
    * `q_psd_diag`.
    *
-   * The noise model uses the covariance produced by `buildWNOACovariance`.
+   * The noise model uses the covariance produced by `BuildWNOACovariance`.
    *
    * @param timestep Time interval
    * @param q_psd_diag Diagonal PSD vector
    * @return noiseModel::Gaussian::shared_ptr Noise model built from covariance
    */
-  static inline noiseModel::Gaussian::shared_ptr buildWNOANoiseModel(
+  static inline noiseModel::Gaussian::shared_ptr BuildWNOANoiseModel(
       double timestep, const VectorN& q_psd_diag) {
     return noiseModel::Gaussian::Covariance(
-        buildWNOACovariance(timestep, q_psd_diag));
+        BuildWNOACovariance(timestep, q_psd_diag));
   }
 
   /**
@@ -381,8 +358,7 @@ class WNOAMotionFactor
     MatrixN invJr;
     MatrixN dxi_dT1;
     MatrixN dvErr_dxi;
-    computeRelativePose(p1, p2, v2, &xi, &invJr, &dxi_dT1, nullptr,
-                         &dvErr_dxi);
+    ComputeRelativePose(p1, p2, v2, xi, invJr, &dxi_dT1, nullptr, &dvErr_dxi);
 
     Matrix2N F;
     // first column is pose, second column is velocity
@@ -415,8 +391,7 @@ class WNOAMotionFactor
     MatrixN invJr;
     MatrixN dxi_dT2;
     MatrixN dvErr_dxi;
-    computeRelativePose(p1, p2, v2, &xi, &invJr, nullptr, &dxi_dT2,
-                         &dvErr_dxi);
+    ComputeRelativePose(p1, p2, v2, xi, invJr, nullptr, &dxi_dT2, &dvErr_dxi);
 
     Matrix2N E;
     // First column is pose, second column is velocity

--- a/gtsam/nonlinear/WNOAInterpolator.cpp
+++ b/gtsam/nonlinear/WNOAInterpolator.cpp
@@ -33,11 +33,11 @@ Interpolator<PoseType>::Interpolator(
 
 template <typename PoseType>
 Interpolator<PoseType>::Interpolator(const VectorN& Q_psd)
-    : Interpolator(Q_psd, WNOAMotionFactor<PoseType>::transitionFunction,
+    : Interpolator(Q_psd, WNOAMotionFactor<PoseType>::TransitionFunction,
                    WNOAMotionFactor<PoseType>::BuildWNOACovariance,
                    WNOAMotionFactor<PoseType>::BuildInverseWNOACovariance,
-                   WNOAMotionFactor<PoseType>::computeJacobianPrev,
-                   WNOAMotionFactor<PoseType>::computeJacobianNext) {}
+                   WNOAMotionFactor<PoseType>::ComputeJacobianPrev,
+                   WNOAMotionFactor<PoseType>::ComputeJacobianNext) {}
 
 // ---- Member Functions ----
 template <typename PoseType>

--- a/gtsam/nonlinear/WNOAInterpolator.cpp
+++ b/gtsam/nonlinear/WNOAInterpolator.cpp
@@ -34,8 +34,8 @@ Interpolator<PoseType>::Interpolator(
 template <typename PoseType>
 Interpolator<PoseType>::Interpolator(const VectorN& Q_psd)
     : Interpolator(Q_psd, WNOAMotionFactor<PoseType>::transitionFunction,
-                   WNOAMotionFactor<PoseType>::buildWNOACovariance,
-                   WNOAMotionFactor<PoseType>::buildInverseWNOACovariance,
+                   WNOAMotionFactor<PoseType>::BuildWNOACovariance,
+                   WNOAMotionFactor<PoseType>::BuildInverseWNOACovariance,
                    WNOAMotionFactor<PoseType>::computeJacobianPrev,
                    WNOAMotionFactor<PoseType>::computeJacobianNext) {}
 

--- a/gtsam/nonlinear/WNOAInterpolator.cpp
+++ b/gtsam/nonlinear/WNOAInterpolator.cpp
@@ -141,22 +141,14 @@ Interpolator<PoseType>::interpolateBoundaryRight(
     const std::shared_ptr<Matrix>& mainSolveMarginalMatrix,
     Matrix* covarianceOut) const {
   if (H) {
-    // dTtau_dTk
-    (*H)[0] = MatrixN::Zero();
-    // dTtau_dvarpik
-    (*H)[1] = MatrixN::Zero();
-    // dTtau_dTkp1
-    (*H)[2] = MatrixN::Identity();
-    // dTtau_dvarpikp1
-    (*H)[3] = MatrixN::Zero();
-    // dvarpitau_dTk
-    (*H)[4] = MatrixN::Zero();
-    // dvarpitau_dvarpik
-    (*H)[5] = MatrixN::Zero();
-    // dvarpitau_dTkp1
-    (*H)[6] = MatrixN::Zero();
-    // dvarpitau_dvarpikp1
-    (*H)[7] = MatrixN::Identity();
+    (*H)[0] = MatrixN::Zero();      // dTtau_dTk
+    (*H)[1] = MatrixN::Zero();      // dTtau_dvarpik
+    (*H)[2] = MatrixN::Identity();  // dTtau_dTkp1
+    (*H)[3] = MatrixN::Zero();      // dTtau_dvarpikp1
+    (*H)[4] = MatrixN::Zero();      // dvarpitau_dTk
+    (*H)[5] = MatrixN::Zero();      // dvarpitau_dvarpik
+    (*H)[6] = MatrixN::Zero();      // dvarpitau_dTkp1
+    (*H)[7] = MatrixN::Identity();  // dvarpitau_dvarpikp1
   }
   if (covarianceOut && mainSolveMarginalMatrix) {
     // if t_tau == t_kp1, then the covariance is the same as that of Tvarpi_kp1
@@ -221,18 +213,11 @@ Interpolator<PoseType>::interpolatePoseAndVelocity_(
   // 1. Form local state vectors and Jacobians
   // Form local state vectors at time k, in the Lie algebra of Pose at time k
   // Follows Eq. (11.45) in (Barfoot 2024)
-  VectorN xi_k;
+  VectorN xi_k, xi_dot_k, xi_kp1, xi_dot_kp1;
   xi_k.setZero();
-  VectorN xi_dot_k;
-  VectorN xi_kp1;
-  VectorN xi_dot_kp1;
   // Intermediate Jacobians for xi and xi_dot at next time step with respect to
   // the bordering states and velocities
-  MatrixN dxi_dTk;
-  MatrixN dxi_dTkp1;
-  MatrixN dxidot_dTk;
-  MatrixN dxidot_dTkp1;
-  MatrixN dxidotkp1_dvarpikp1;
+  MatrixN dxi_dTk, dxi_dTkp1, dxidot_dTk, dxidot_dTkp1, dxidotkp1_dvarpikp1;
   if (H) {
     formLocalStateAndJacobians_(tPoseVel_k, tPoseVel_kp1, localStateVecsPreComp,
                                 localGlobalStateJacsPreComp, &xi_dot_k, &xi_kp1,
@@ -248,15 +233,12 @@ Interpolator<PoseType>::interpolatePoseAndVelocity_(
   Matrix2N Lambda, Psi;
   // Compute local state vectors at time tau, in the Lie algebra of Pose at time
   // k, using WNOA interpolation equations
-  VectorN xi_tau;
-  VectorN xidot_tau;
+  VectorN xi_tau, xidot_tau;
   interpolateLocalState_(t_k, t_kp1, t_tau, xi_dot_k, xi_kp1, xi_dot_kp1,
                          LambdaPsiPreComp, &Lambda, &Psi, &xi_tau, &xidot_tau);
   // 3. Map to manifold
   // Additional intermediate Jacobians
-  MatrixN right_jac_tau;
-  MatrixN dTtau_dTk;
-  MatrixN dTtau_dxitau;
+  MatrixN right_jac_tau, dTtau_dTk, dTtau_dxitau;
   // Map the local state vector at time tau back to the manifold to get the
   // interpolated pose Eq. (11.45) in (Barfoot 2024)
   PoseVel poseVel_tau;
@@ -302,46 +284,34 @@ void Interpolator<PoseType>::formLocalStateAndJacobians_(
   const auto& [_T_k, varpi_k] = poseVel_k;
   *xi_dot_k = varpi_k;
 
+  const bool needComputedState =
+      !localStateVecsPreComp || (computeJacs && !localGlobalStateJacsPreComp);
+
+  LocalStateVecs local_state;
+  LocalGlobalStateJacs local_jacs;
+  if (needComputedState) {
+    local_state = computeLocalStateVecs(tPoseVel_k, tPoseVel_kp1,
+                                        computeJacs ? &local_jacs : nullptr);
+  }
+
+  // State vectors come from precompute if available, otherwise from local.
   if (localStateVecsPreComp) {
-    // If precomputation of local state vectors is provided, use it to save
-    // computation
     *xi_kp1 = localStateVecsPreComp->first;
     *xi_dot_kp1 = localStateVecsPreComp->second;
-
-    if (computeJacs && localGlobalStateJacsPreComp) {
-      *dxi_dTk = localGlobalStateJacsPreComp->at(0);
-      *dxi_dTkp1 = localGlobalStateJacsPreComp->at(1);
-      *dxidot_dTk = localGlobalStateJacsPreComp->at(2);
-      *dxidot_dTkp1 = localGlobalStateJacsPreComp->at(3);
-      *dxidotkp1_dvarpikp1 = localGlobalStateJacsPreComp->at(4);
-    } else if (computeJacs) {
-      LocalGlobalStateJacs local_jacs;
-      const LocalStateVecs local_state =
-          computeLocalStateVecs(tPoseVel_k, tPoseVel_kp1, &local_jacs);
-      *xi_kp1 = local_state.first;
-      *xi_dot_kp1 = local_state.second;
-      *dxi_dTk = local_jacs[0];
-      *dxi_dTkp1 = local_jacs[1];
-      *dxidot_dTk = local_jacs[2];
-      *dxidot_dTkp1 = local_jacs[3];
-      *dxidotkp1_dvarpikp1 = local_jacs[4];
-    }
   } else {
-    LocalStateVecs local_state;
-    LocalGlobalStateJacs local_jacs;
-    if (computeJacs) {
-      local_state =
-          computeLocalStateVecs(tPoseVel_k, tPoseVel_kp1, &local_jacs);
-      *dxi_dTk = local_jacs[0];
-      *dxi_dTkp1 = local_jacs[1];
-      *dxidot_dTk = local_jacs[2];
-      *dxidot_dTkp1 = local_jacs[3];
-      *dxidotkp1_dvarpikp1 = local_jacs[4];
-    } else {
-      local_state = computeLocalStateVecs(tPoseVel_k, tPoseVel_kp1, nullptr);
-    }
     *xi_kp1 = local_state.first;
     *xi_dot_kp1 = local_state.second;
+  }
+
+  if (computeJacs) {
+    // Jacobians come from precompute if available, otherwise from local.
+    const LocalGlobalStateJacs& jacs =
+        localGlobalStateJacsPreComp ? *localGlobalStateJacsPreComp : local_jacs;
+    *dxi_dTk = jacs[0];
+    *dxi_dTkp1 = jacs[1];
+    *dxidot_dTk = jacs[2];
+    *dxidot_dTkp1 = jacs[3];
+    *dxidotkp1_dvarpikp1 = jacs[4];
   }
 }
 
@@ -465,7 +435,7 @@ void Interpolator<PoseType>::computeInterpolationCovariance_(
 
 template <typename PoseType>
 std::map<StateDataInterval, std::shared_ptr<Matrix>>
-Interpolator<PoseType>::computeJointMarginals(
+Interpolator<PoseType>::ComputeJointMarginals(
     const std::map<StateDataInterval, std::vector<StateData>>& queryBuckets,
     const std::unique_ptr<Marginals>& marginals) {
   std::map<StateDataInterval, std::shared_ptr<Matrix>>
@@ -496,7 +466,7 @@ Interpolator<PoseType>::computeJointMarginals(
     // avoid using JointMarginal.fullMatrix() as it returns covariance
     // in alphabetical order of the keys...
     auto mainSolveMarginalMatrix =
-        std::make_shared<Matrix>(constructMatrixFromJointMarginal(
+        std::make_shared<Matrix>(ConstructMatrixFromJointMarginal(
             mainSolveMarginal, boundaryKeyVector, dim));
     intervalJointMarginals[stateDataBorders] = mainSolveMarginalMatrix;
   }
@@ -537,7 +507,7 @@ Values Interpolator<PoseType>::interpolatePosesAndVelocities(
     // Compute all required joint marginals
     fullMarginal =
         std::make_unique<Marginals>(mainSolveGraph, mainSolveSolution);
-    intervalJointMarginals = computeJointMarginals(queryBuckets, fullMarginal);
+    intervalJointMarginals = ComputeJointMarginals(queryBuckets, fullMarginal);
   }
 
   // Perform interpolation for each bucket
@@ -662,8 +632,8 @@ Interpolator<PoseType>::computeLocalStateVecs(
     dxi_dTk = invJr * dbetween_Tk;
     dxi_dTkp1 = invJr * dbetween_Tkp1;
   } else {
-    xi_kp1 = traits<PoseType>::Logmap(traits<PoseType>::Between(T_k, T_kp1),
-                                      &invJr);
+    xi_kp1 =
+        traits<PoseType>::Logmap(traits<PoseType>::Between(T_k, T_kp1), &invJr);
   }
   xi_dot_kp1 = invJr * varpi_kp1;
   LocalStateVecs local_state;
@@ -736,7 +706,7 @@ Interpolator<PoseType>::computeConditionalCov(
 }
 
 template <typename PoseType>
-Matrix Interpolator<PoseType>::constructMatrixFromJointMarginal(
+Matrix Interpolator<PoseType>::ConstructMatrixFromJointMarginal(
     const JointMarginal& blockMatrix, const KeyVector& keyVector,
     size_t blockSize) {
   size_t n = keyVector.size();

--- a/gtsam/nonlinear/WNOAInterpolator.cpp
+++ b/gtsam/nonlinear/WNOAInterpolator.cpp
@@ -50,8 +50,7 @@ Interpolator<PoseType>::interpolatePoseAndVelocity(
     Matrix* covarianceOut,
     const std::shared_ptr<const LambdaPsiMats>& LambdaPsiPreComp,
     const std::shared_ptr<const LocalStateVecs>& localStateVecsPreComp,
-    const std::shared_ptr<const LocalGlobalStateJacs>&
-        localGlobalStateJacsPreComp) const {
+    const std::shared_ptr<const StateJacobians>& stateJacobiansPreComp) const {
   assert((tPoseVel_k.has_value() || tPoseVel_kp1.has_value()) &&
          "At least one TimestampedPoseVel must be defined");
   // second point not defined, extrap from first
@@ -99,7 +98,7 @@ Interpolator<PoseType>::interpolatePoseAndVelocity(
     return interpolatePoseAndVelocity_(
         tPoseVel_k.value(), tPoseVel_kp1.value(), t_tau, H,
         mainSolveMarginalMatrix, covarianceOut, LambdaPsiPreComp,
-        localStateVecsPreComp, localGlobalStateJacsPreComp);
+        localStateVecsPreComp, stateJacobiansPreComp);
   }
 }
 
@@ -203,8 +202,7 @@ Interpolator<PoseType>::interpolatePoseAndVelocity_(
     Matrix* covarianceOut,
     const std::shared_ptr<const LambdaPsiMats>& LambdaPsiPreComp,
     const std::shared_ptr<const LocalStateVecs>& localStateVecsPreComp,
-    const std::shared_ptr<const LocalGlobalStateJacs>&
-        localGlobalStateJacsPreComp) const {
+    const std::shared_ptr<const StateJacobians>& stateJacobiansPreComp) const {
   // unpack poses and velocities
   const auto& [poseVel_k, t_k] = tPoseVel_k;
   const auto& [T_k, varpi_k] = poseVel_k;
@@ -217,15 +215,14 @@ Interpolator<PoseType>::interpolatePoseAndVelocity_(
   xi_k.setZero();
   // Intermediate Jacobians for xi and xi_dot at next time step with respect to
   // the bordering states and velocities
-  MatrixN dxi_dTk, dxi_dTkp1, dxidot_dTk, dxidot_dTkp1, dxidotkp1_dvarpikp1;
+  StateJacobians localJacs;
   if (H) {
     formLocalStateAndJacobians_(tPoseVel_k, tPoseVel_kp1, localStateVecsPreComp,
-                                localGlobalStateJacsPreComp, &xi_dot_k, &xi_kp1,
-                                &xi_dot_kp1, &dxi_dTk, &dxi_dTkp1, &dxidot_dTk,
-                                &dxidot_dTkp1, &dxidotkp1_dvarpikp1);
+                                stateJacobiansPreComp, &xi_dot_k, &xi_kp1,
+                                &xi_dot_kp1, &localJacs);
   } else {
     formLocalStateAndJacobians_(tPoseVel_k, tPoseVel_kp1, localStateVecsPreComp,
-                                localGlobalStateJacsPreComp, &xi_dot_k, &xi_kp1,
+                                stateJacobiansPreComp, &xi_dot_k, &xi_kp1,
                                 &xi_dot_kp1);
   }
   // 2. Interpolation
@@ -253,8 +250,7 @@ Interpolator<PoseType>::interpolatePoseAndVelocity_(
   // 4. Compute complete Jacobians
   if (H) {
     computeCompleteJacobians_(Lambda, Psi, xidot_tau, right_jac_tau, dTtau_dTk,
-                              dTtau_dxitau, dxi_dTk, dxi_dTkp1, dxidot_dTk,
-                              dxidot_dTkp1, dxidotkp1_dvarpikp1, H);
+                              dTtau_dxitau, localJacs, H);
   }
 
   // 5. Compute covariance of the interpolated pose and velocity
@@ -272,26 +268,21 @@ void Interpolator<PoseType>::formLocalStateAndJacobians_(
     const TimestampedPoseVel& tPoseVel_k,
     const TimestampedPoseVel& tPoseVel_kp1,
     const std::shared_ptr<const LocalStateVecs>& localStateVecsPreComp,
-    const std::shared_ptr<const LocalGlobalStateJacs>&
-        localGlobalStateJacsPreComp,
-    VectorN* xi_dot_k, VectorN* xi_kp1, VectorN* xi_dot_kp1, MatrixN* dxi_dTk,
-    MatrixN* dxi_dTkp1, MatrixN* dxidot_dTk, MatrixN* dxidot_dTkp1,
-    MatrixN* dxidotkp1_dvarpikp1) const {
-  const bool computeJacs =
-      dxi_dTk && dxi_dTkp1 && dxidot_dTk && dxidot_dTkp1 && dxidotkp1_dvarpikp1;
-
+    const std::shared_ptr<const StateJacobians>& stateJacobiansPreComp,
+    VectorN* xi_dot_k, VectorN* xi_kp1, VectorN* xi_dot_kp1,
+    StateJacobians* jacs) const {
   const auto& [poseVel_k, _t_k] = tPoseVel_k;
   const auto& [_T_k, varpi_k] = poseVel_k;
   *xi_dot_k = varpi_k;
 
   const bool needComputedState =
-      !localStateVecsPreComp || (computeJacs && !localGlobalStateJacsPreComp);
+      !localStateVecsPreComp || (jacs && !stateJacobiansPreComp);
 
   LocalStateVecs local_state;
-  LocalGlobalStateJacs local_jacs;
+  StateJacobians localJacs;
   if (needComputedState) {
     local_state = computeLocalStateVecs(tPoseVel_k, tPoseVel_kp1,
-                                        computeJacs ? &local_jacs : nullptr);
+                                        jacs ? &localJacs : nullptr);
   }
 
   // State vectors come from precompute if available, otherwise from local.
@@ -303,15 +294,9 @@ void Interpolator<PoseType>::formLocalStateAndJacobians_(
     *xi_dot_kp1 = local_state.second;
   }
 
-  if (computeJacs) {
+  if (jacs) {
     // Jacobians come from precompute if available, otherwise from local.
-    const LocalGlobalStateJacs& jacs =
-        localGlobalStateJacsPreComp ? *localGlobalStateJacsPreComp : local_jacs;
-    *dxi_dTk = jacs[0];
-    *dxi_dTkp1 = jacs[1];
-    *dxidot_dTk = jacs[2];
-    *dxidot_dTkp1 = jacs[3];
-    *dxidotkp1_dvarpikp1 = jacs[4];
+    *jacs = stateJacobiansPreComp ? *stateJacobiansPreComp : localJacs;
   }
 }
 
@@ -361,9 +346,7 @@ template <typename PoseType>
 void Interpolator<PoseType>::computeCompleteJacobians_(
     const Matrix2N& Lambda, const Matrix2N& Psi, const VectorN& xidot_tau,
     const MatrixN& right_jac_tau, const MatrixN& dTtau_dTk,
-    const MatrixN& dTtau_dxitau, const MatrixN& dxi_dTk,
-    const MatrixN& dxi_dTkp1, const MatrixN& dxidot_dTk,
-    const MatrixN& dxidot_dTkp1, const MatrixN& dxidotkp1_dvarpikp1,
+    const MatrixN& dTtau_dxitau, const StateJacobians& jacs,
     OptionalMatrixVecType H) const {
   // Zero for vector spaces, use an approximation for Lie groups
   MatrixN dvarpitau_dxitau;
@@ -377,24 +360,27 @@ void Interpolator<PoseType>::computeCompleteJacobians_(
 
   // derivatives of local state position at time tau with respect to bordering
   // states and velocities
-  MatrixN dxitau_dTk = Psi(0, 0) * dxi_dTk + Psi(0, dim) * dxidot_dTk;
+  MatrixN dxitau_dTk = Psi(0, 0) * jacs.dxi_dTk + Psi(0, dim) * jacs.dxidot_dTk;
   MatrixN dxitau_dvarpik =
       Lambda(0, dim) * MatrixN::Identity();  // xi does not depend on varpi_k
                                              // and xi_dot is exactly varpi_k
-  MatrixN dxitau_dTkp1 = Psi(0, 0) * dxi_dTkp1 + Psi(0, dim) * dxidot_dTkp1;
+  MatrixN dxitau_dTkp1 =
+      Psi(0, 0) * jacs.dxi_dTkp1 + Psi(0, dim) * jacs.dxidot_dTkp1;
   MatrixN dxitau_dvarpikp1 =
-      Psi(0, dim) * dxidotkp1_dvarpikp1;  // dxikp1 does not depend on varpi_kp1
+      Psi(0, dim) *
+      jacs.dxidotkp1_dvarpikp1;  // dxikp1 does not depend on varpi_kp1
   // derivatives of local state velocity at time tau with respect to bordering
   // states and velocities
-  MatrixN dxidottau_dTk = Psi(dim, 0) * dxi_dTk + Psi(dim, dim) * dxidot_dTk;
+  MatrixN dxidottau_dTk =
+      Psi(dim, 0) * jacs.dxi_dTk + Psi(dim, dim) * jacs.dxidot_dTk;
   MatrixN dxidottau_dvarpik =
       Lambda(dim, dim) * MatrixN::Identity();  // xi does not depend on varpi_k
                                                // and xi_dot is exactly varpi_k
   MatrixN dxidottau_dTkp1 =
-      Psi(dim, 0) * dxi_dTkp1 + Psi(dim, dim) * dxidot_dTkp1;
+      Psi(dim, 0) * jacs.dxi_dTkp1 + Psi(dim, dim) * jacs.dxidot_dTkp1;
   MatrixN dxidottau_dvarpikp1 =
       Psi(dim, dim) *
-      dxidotkp1_dvarpikp1;  // dxikp1 does not depend on varpi_kp1
+      jacs.dxidotkp1_dvarpikp1;  // dxikp1 does not depend on varpi_kp1
   // Compose final Jacobians using chain rule
   // dTtau_dTk
   (*H)[0] = dTtau_dTk + dTtau_dxitau * dxitau_dTk;
@@ -610,7 +596,7 @@ template <typename PoseType>
 typename Interpolator<PoseType>::LocalStateVecs
 Interpolator<PoseType>::computeLocalStateVecs(
     const TimestampedPoseVel& pvk, const TimestampedPoseVel& pvkp1,
-    Interpolator<PoseType>::LocalGlobalStateJacs* jacs) const {
+    Interpolator<PoseType>::StateJacobians* jacs) const {
   const auto& [poseVel_k, t_k] = pvk;
   const auto& [poseVel_kp1, t_kp1] = pvkp1;
   const auto& [T_k, varpi_k] = poseVel_k;
@@ -618,9 +604,6 @@ Interpolator<PoseType>::computeLocalStateVecs(
 
   VectorN xi_kp1, xi_dot_kp1;
   MatrixN invJr;
-  MatrixN dxi_dTk, dxi_dTkp1;
-  MatrixN dxidot_dTk, dxidot_dTkp1;
-  MatrixN dxidotkp1_dvarpikp1;
 
   if (jacs) {
     MatrixN dbetween_Tk;
@@ -629,8 +612,8 @@ Interpolator<PoseType>::computeLocalStateVecs(
         traits<PoseType>::Between(T_k, T_kp1, &dbetween_Tk, &dbetween_Tkp1),
         &invJr);
     // Compute derivatives
-    dxi_dTk = invJr * dbetween_Tk;
-    dxi_dTkp1 = invJr * dbetween_Tkp1;
+    jacs->dxi_dTk = invJr * dbetween_Tk;
+    jacs->dxi_dTkp1 = invJr * dbetween_Tkp1;
   } else {
     xi_kp1 =
         traits<PoseType>::Logmap(traits<PoseType>::Between(T_k, T_kp1), &invJr);
@@ -650,16 +633,9 @@ Interpolator<PoseType>::computeLocalStateVecs(
       // For Lie groups
       dxidot_dxi = -PoseType::adjointMap(varpi_kp1) / 2.0;
     }
-    dxidot_dTk = dxidot_dxi * dxi_dTk;
-    dxidot_dTkp1 = dxidot_dxi * dxi_dTkp1;
-    dxidotkp1_dvarpikp1 = invJr;
-
-    jacs->clear();
-    jacs->push_back(dxi_dTk);
-    jacs->push_back(dxi_dTkp1);
-    jacs->push_back(dxidot_dTk);
-    jacs->push_back(dxidot_dTkp1);
-    jacs->push_back(dxidotkp1_dvarpikp1);
+    jacs->dxidot_dTk = dxidot_dxi * jacs->dxi_dTk;
+    jacs->dxidot_dTkp1 = dxidot_dxi * jacs->dxi_dTkp1;
+    jacs->dxidotkp1_dvarpikp1 = invJr;
   }
 
   return local_state;

--- a/gtsam/nonlinear/WNOAInterpolator.h
+++ b/gtsam/nonlinear/WNOAInterpolator.h
@@ -574,7 +574,7 @@ class GTSAM_EXPORT Interpolator {
    * marginal matrices.
    */
   static std::map<StateDataInterval, std::shared_ptr<Matrix>>
-  computeJointMarginals(
+  ComputeJointMarginals(
       const std::map<StateDataInterval, std::vector<StateData>>& queryBuckets,
       const std::unique_ptr<Marginals>& marginals);
 
@@ -592,7 +592,7 @@ class GTSAM_EXPORT Interpolator {
    * block).
    * @return Matrix Full covariance matrix assembled from the joint marginal.
    */
-  static Matrix constructMatrixFromJointMarginal(
+  static Matrix ConstructMatrixFromJointMarginal(
       const JointMarginal& blockMatrix, const KeyVector& keyVector,
       size_t blockSize);
 };

--- a/gtsam/nonlinear/WNOAInterpolator.h
+++ b/gtsam/nonlinear/WNOAInterpolator.h
@@ -136,7 +136,13 @@ class GTSAM_EXPORT Interpolator {
   using TimestampedPoseVel = TimestampedPoseVelocity<PoseType>;
   using LambdaPsiMats = std::pair<Matrix2N, Matrix2N>;
   using LocalStateVecs = std::pair<VectorN, VectorN>;
-  using LocalGlobalStateJacs = std::vector<MatrixN>;
+  struct StateJacobians {
+    MatrixN dxi_dTk;
+    MatrixN dxi_dTkp1;
+    MatrixN dxidot_dTk;
+    MatrixN dxidot_dTkp1;
+    MatrixN dxidotkp1_dvarpikp1;
+  };
 
   // Maps a pose or velocity to their covariance matrix
   using CovarianceMap = std::map<Key, Matrix>;
@@ -202,7 +208,7 @@ class GTSAM_EXPORT Interpolator {
    * work.
    * @param localStateVecsPreComp Optional precomputed local state vectors (xi,
    * xi_dot).
-   * @param localGlobalStateJacsPreComp Optional precomputed local state->global
+   * @param stateJacobiansPreComp Optional precomputed local state->global
    * state Jacobians.
    * @return PoseVel Interpolated pose and velocity pair at `t_tau`.
    */
@@ -215,8 +221,8 @@ class GTSAM_EXPORT Interpolator {
       const std::shared_ptr<const LambdaPsiMats>& LambdaPsiPreComp = nullptr,
       const std::shared_ptr<const LocalStateVecs>& localStateVecsPreComp =
           nullptr,
-      const std::shared_ptr<const LocalGlobalStateJacs>&
-          localGlobalStateJacsPreComp = nullptr) const;
+      const std::shared_ptr<const StateJacobians>& stateJacobiansPreComp =
+          nullptr) const;
 
   /**
    * @brief Interpolate multiple poses and velocities given a solved factor
@@ -310,9 +316,9 @@ class GTSAM_EXPORT Interpolator {
    * @param jacs Optional output pointer to receive local-to-global Jacobians.
    * @return LocalStateVecs Pair of local state vectors (xi, xi_dot).
    */
-  LocalStateVecs computeLocalStateVecs(
-      const TimestampedPoseVel& pvk, const TimestampedPoseVel& pvkp1,
-      LocalGlobalStateJacs* jacs = nullptr) const;
+  LocalStateVecs computeLocalStateVecs(const TimestampedPoseVel& pvk,
+                                       const TimestampedPoseVel& pvkp1,
+                                       StateJacobians* jacs = nullptr) const;
 
  protected:
   /**
@@ -409,7 +415,7 @@ class GTSAM_EXPORT Interpolator {
    * work.
    * @param localStateVecsPreComp Optional precomputed local state vectors (xi,
    * xi_dot).
-   * @param localGlobalStateJacsPreComp Optional precomputed local->global
+   * @param stateJacobiansPreComp Optional precomputed local->global
    * Jacobians.
    * @return PoseVel Interpolated pose and velocity at `t_tau`.
    */
@@ -422,8 +428,8 @@ class GTSAM_EXPORT Interpolator {
       const std::shared_ptr<const LambdaPsiMats>& LambdaPsiPreComp = nullptr,
       const std::shared_ptr<const LocalStateVecs>& localStateVecsPreComp =
           nullptr,
-      const std::shared_ptr<const LocalGlobalStateJacs>&
-          localGlobalStateJacsPreComp = nullptr) const;
+      const std::shared_ptr<const StateJacobians>& stateJacobiansPreComp =
+          nullptr) const;
 
   /**
    * @brief Step 1 of interpolatePoseAndVelocity: form local state vectors and
@@ -437,30 +443,21 @@ class GTSAM_EXPORT Interpolator {
    * @param tPoseVel_kp1 Timestamped right border state.
    * @param localStateVecsPreComp Optional precomputed local state vectors at
    * the right border.
-   * @param localGlobalStateJacsPreComp Optional precomputed local-to-global
+   * @param stateJacobiansPreComp Optional precomputed local-to-global
    * Jacobians.
    * @param xi_dot_k Output local velocity vector at the left border.
    * @param xi_kp1 Output local position vector at the right border.
    * @param xi_dot_kp1 Output local velocity vector at the right border.
-   * @param dxi_dTk Optional output Jacobian of $\xi_{k+1}$ wrt $T_k$.
-   * @param dxi_dTkp1 Optional output Jacobian of $\xi_{k+1}$ wrt $T_{k+1}$.
-   * @param dxidot_dTk Optional output Jacobian of $\dot\xi_{k+1}$ wrt $T_k$.
-   * @param dxidot_dTkp1 Optional output Jacobian of
-   * $\dot\xi_{k+1}$ wrt $T_{k+1}$.
-   * @param dxidotkp1_dvarpikp1 Optional output Jacobian of
-   * $\dot\xi_{k+1}$ wrt $\varpi_{k+1}$.
+   * @param jacs Optional output Jacobians for local state wrt bordering states.
    * @return void
    */
   void formLocalStateAndJacobians_(
       const TimestampedPoseVel& tPoseVel_k,
       const TimestampedPoseVel& tPoseVel_kp1,
       const std::shared_ptr<const LocalStateVecs>& localStateVecsPreComp,
-      const std::shared_ptr<const LocalGlobalStateJacs>&
-          localGlobalStateJacsPreComp,
+      const std::shared_ptr<const StateJacobians>& stateJacobiansPreComp,
       VectorN* xi_dot_k, VectorN* xi_kp1, VectorN* xi_dot_kp1,
-      MatrixN* dxi_dTk = nullptr, MatrixN* dxi_dTkp1 = nullptr,
-      MatrixN* dxidot_dTk = nullptr, MatrixN* dxidot_dTkp1 = nullptr,
-      MatrixN* dxidotkp1_dvarpikp1 = nullptr) const;
+      StateJacobians* jacs = nullptr) const;
 
   /**
    * @brief Step 2 of interpolatePoseAndVelocity: interpolate local state using
@@ -520,22 +517,17 @@ class GTSAM_EXPORT Interpolator {
    * @param right_jac_tau Right Jacobian of `Expmap(xi_tau)`.
    * @param dTtau_dTk Jacobian of $T_\tau$ wrt $T_k$ from composition.
    * @param dTtau_dxitau Jacobian of $T_\tau$ wrt $\xi_\tau$.
-   * @param dxi_dTk Jacobian of $\xi_{k+1}$ wrt $T_k$.
-   * @param dxi_dTkp1 Jacobian of $\xi_{k+1}$ wrt $T_{k+1}$.
-   * @param dxidot_dTk Jacobian of $\dot\xi_{k+1}$ wrt $T_k$.
-   * @param dxidot_dTkp1 Jacobian of $\dot\xi_{k+1}$ wrt $T_{k+1}$.
-   * @param dxidotkp1_dvarpikp1 Jacobian of $\dot\xi_{k+1}$ wrt
-   * $\varpi_{k+1}$.
+   * @param jacs Jacobians for local state wrt bordering states.
    * @param H Output vector of Jacobian blocks to populate.
    * @return void
    */
-  void computeCompleteJacobians_(
-      const Matrix2N& Lambda, const Matrix2N& Psi, const VectorN& xidot_tau,
-      const MatrixN& right_jac_tau, const MatrixN& dTtau_dTk,
-      const MatrixN& dTtau_dxitau, const MatrixN& dxi_dTk,
-      const MatrixN& dxi_dTkp1, const MatrixN& dxidot_dTk,
-      const MatrixN& dxidot_dTkp1, const MatrixN& dxidotkp1_dvarpikp1,
-      OptionalMatrixVecType H) const;
+  void computeCompleteJacobians_(const Matrix2N& Lambda, const Matrix2N& Psi,
+                                 const VectorN& xidot_tau,
+                                 const MatrixN& right_jac_tau,
+                                 const MatrixN& dTtau_dTk,
+                                 const MatrixN& dTtau_dxitau,
+                                 const StateJacobians& jacs,
+                                 OptionalMatrixVecType H) const;
 
   /**
    * @brief Step 5 of interpolatePoseAndVelocity: compute interpolated

--- a/gtsam/nonlinear/WNOAStateData.h
+++ b/gtsam/nonlinear/WNOAStateData.h
@@ -37,14 +37,9 @@ namespace gtsam {
  * constructing interpolation queries.
  */
 struct GTSAM_EXPORT StateData {
-  /// Key of the pose variable
-  Key pose;
-
-  /// Key of the velocity variable
-  Key velocity;
-
-  /// Timestamp (seconds) associated with this state
-  double time;
+  Key pose;      ///< Key of the pose variable
+  Key velocity;  ///< Key of the velocity variable
+  double time;   ///< Timestamp (seconds) associated with this state
 
   /// Default constructor.
   StateData() = default;


### PR DESCRIPTION
This PR contains 5 commits from review work on PR #2411, split out for easier review/cherry-pick instead of pushing directly to ct-gp-pr/wnoa-factors.

Highlights:
- tighten/clean header API/comments
- naming and formatting consistency pass
- reference/static naming cleanup
- StateJacobians struct refactor to reduce argument plumbing

Please cherry-pick as desired.