### PR TITLE
WNOAInterpFactor helper cleanup and overload coverage

### DIFF
--- a/gtsam/nonlinear/WNOAInterpFactor.h
+++ b/gtsam/nonlinear/WNOAInterpFactor.h
@@ -385,39 +385,14 @@ class WNOAInterpFactor : public NoiseModelFactor {
    * interpolated conditional covariances.
    */
   std::shared_ptr<GaussianFactor> linearize(const Values& x) const override {
-    // if noise model fixed, just use the NonlinearFactor linearize approach.
-    if (fixed_noise_model_) {
-      return Base::linearize(x);
-    }
-
     // Only linearize if the factor is active
     if (!active(x)) return std::shared_ptr<JacobianFactor>();
 
-    // Call evaluate error to get Jacobians and RHS vector b
+    // Compute residual and effective noise model.
     std::vector<Matrix> A(size());
-    std::vector<Matrix> JacInner(inner_factor_->size());
-    std::unordered_map<StateData, Matrix2N> InterpCondCovs;
-    Vector b = -computeInterpolatedError(x, &A, &JacInner, &InterpCondCovs);
-    // get interpolated noise model
-    auto noise_model = getInterpolatedNoiseModel(JacInner, InterpCondCovs);
-    // Whiten the corresponding system now
-    noise_model->WhitenSystem(A, b);
-
-    // Fill in terms, needed to create JacobianFactor below
-    std::vector<std::pair<Key, Matrix>> terms(size());
-    for (size_t j = 0; j < size(); ++j) {
-      terms[j].first = keys()[j];
-      terms[j].second.swap(A[j]);
-    }
-    // Build final Guassian Factor
-    using noiseModel::Constrained;
-    if (noiseModel_ && noiseModel_->isConstrained())
-      return GaussianFactor::shared_ptr(new JacobianFactor(
-          terms, b,
-          std::static_pointer_cast<Constrained>(noiseModel_)->unit()));
-    else {
-      return GaussianFactor::shared_ptr(new JacobianFactor(terms, b));
-    }
+    Vector b;
+    auto noise_model = eval(x, nullptr, b, &A);
+    return makeJacobianFactor(A, b, noise_model);
   }
 
   /**
@@ -433,43 +408,11 @@ class WNOAInterpFactor : public NoiseModelFactor {
     // Only linearize if the factor is active
     if (!active(x)) return std::shared_ptr<JacobianFactor>();
 
-    // Call evaluate error to get Jacobians and RHS vector b
+    // Compute residual and effective noise model.
     std::vector<Matrix> A(size());
-    std::vector<Matrix> JacInner(inner_factor_->size());
-    std::unordered_map<StateData, Matrix2N>* InterpCondCovs =
-        nullptr;  // Store a pointer so we don't copy the passed data
     Vector b;
-    noiseModel::Gaussian::shared_ptr noise_model;
-    if (fixed_noise_model_) {
-      b = -computeInterpolatedError(x, &A, nullptr, nullptr, passedInterpData);
-      noise_model =
-          std::dynamic_pointer_cast<noiseModel::Gaussian>(Base::noiseModel());
-    } else {
-      b = -computeInterpolatedError(x, &A, &JacInner, nullptr,
-                                    passedInterpData);
-      InterpCondCovs =
-          &passedInterpData->condCovs;  // set directly from passed data
-      noise_model = getInterpolatedNoiseModel(JacInner, *InterpCondCovs);
-    }
-    // Whiten the corresponding system now
-    noise_model->WhitenSystem(A, b);
-
-    // Fill in terms, needed to create JacobianFactor below
-    std::vector<std::pair<Key, Matrix>> terms(size());
-    for (size_t j = 0; j < size(); ++j) {
-      terms[j].first = keys()[j];
-      terms[j].second.swap(A[j]);
-    }
-
-    // Build final Guassian Factor
-    using noiseModel::Constrained;
-    if (noiseModel_ && noiseModel_->isConstrained())
-      return GaussianFactor::shared_ptr(new JacobianFactor(
-          terms, b,
-          std::static_pointer_cast<Constrained>(noiseModel_)->unit()));
-    else {
-      return GaussianFactor::shared_ptr(new JacobianFactor(terms, b));
-    }
+    auto noise_model = eval(x, passedInterpData, b, &A);
+    return makeJacobianFactor(A, b, noise_model);
   }
 
   /**
@@ -479,30 +422,11 @@ class WNOAInterpFactor : public NoiseModelFactor {
    * evaluating the (possibly augmented) noise model.
    */
   double error(const Values& c) const override {
-    if (active(c)) {
-      Vector b;
-      noiseModel::Gaussian::shared_ptr noise_model;
-      std::vector<Matrix> JacInner(inner_factor_->size());
-      if (fixed_noise_model_) {
-        b = -computeInterpolatedError(c, nullptr, nullptr, nullptr);
-        // if noise model is fixed, just use the base factor's noise model (no
-        // augmentation)
-        noise_model =
-            std::dynamic_pointer_cast<noiseModel::Gaussian>(Base::noiseModel());
-      } else {
-        std::unordered_map<StateData, Matrix2N> InterpCondCovs;
-        b = -computeInterpolatedError(c, nullptr, &JacInner, &InterpCondCovs);
-        // get interpolated noise model that accounts for interpolation
-        // uncertainty
-        noise_model = getInterpolatedNoiseModel(JacInner, InterpCondCovs);
-      }
-      if (noise_model)
-        return noise_model->loss(noise_model->squaredMahalanobisDistance(b));
-      else
-        return 0.5 * b.squaredNorm();
-    } else {
-      return 0.0;
-    }
+    if (!active(c)) return 0.0;
+
+    Vector b;
+    auto noise_model = eval(c, nullptr, b, nullptr);
+    return loss(b, noise_model);
   }
 
   /**
@@ -512,31 +436,11 @@ class WNOAInterpFactor : public NoiseModelFactor {
    * covariances from `passedInterpData` to avoid recomputation.
    */
   double error(const Values& c, PassedInterpData* passedInterpData) const {
-    if (active(c)) {
-      Vector b;
-      noiseModel::Gaussian::shared_ptr noise_model;
-      std::vector<Matrix> JacInner(inner_factor_->size());
-      if (fixed_noise_model_) {
-        b = -computeInterpolatedError(c, nullptr, nullptr, nullptr,
-                                      passedInterpData);
-        noise_model =
-            std::dynamic_pointer_cast<noiseModel::Gaussian>(Base::noiseModel());
-      } else {
-        std::unordered_map<StateData, Matrix2N>* InterpCondCovs =
-            nullptr;  // Store a pointer so we don't copy the passed data
-        b = -computeInterpolatedError(c, nullptr, &JacInner, nullptr,
-                                      passedInterpData);
-        InterpCondCovs =
-            &passedInterpData->condCovs;  // set directly from passed data
-        noise_model = getInterpolatedNoiseModel(JacInner, *InterpCondCovs);
-      }
-      if (noise_model)
-        return noise_model->loss(noise_model->squaredMahalanobisDistance(b));
-      else
-        return 0.5 * b.squaredNorm();
-    } else {
-      return 0.0;
-    }
+    if (!active(c)) return 0.0;
+
+    Vector b;
+    auto noise_model = eval(c, passedInterpData, b, nullptr);
+    return loss(b, noise_model);
   }
 
   /**
@@ -582,6 +486,72 @@ class WNOAInterpFactor : public NoiseModelFactor {
   }
 
  private:
+  /// Compute unwhitened residual and matching Gaussian noise model.
+  noiseModel::Gaussian::shared_ptr eval(const Values& values,
+                                        PassedInterpData* passedInterpData,
+                                        Vector& b,
+                                        std::vector<Matrix>* A) const {
+    if (A && (A->size() != size())) A->resize(size());
+
+    return fixed_noise_model_ ? evalFixed(values, A, passedInterpData, b)
+                              : evalInterp(values, A, passedInterpData, b);
+  }
+
+  /// Compute residual/noise model for fixed-noise mode.
+  noiseModel::Gaussian::shared_ptr evalFixed(const Values& values,
+                                             std::vector<Matrix>* A,
+                                             PassedInterpData* passedInterpData,
+                                             Vector& b) const {
+    b = -computeInterpolatedError(values, A, nullptr, nullptr,
+                                  passedInterpData);
+    return std::dynamic_pointer_cast<noiseModel::Gaussian>(Base::noiseModel());
+  }
+
+  /// Compute residual/noise model for interpolation-augmented noise.
+  noiseModel::Gaussian::shared_ptr evalInterp(
+      const Values& values, std::vector<Matrix>* A,
+      PassedInterpData* passedInterpData, Vector& b) const {
+    std::vector<Matrix> jacInner(inner_factor_->size());
+
+    if (passedInterpData) {
+      b = -computeInterpolatedError(values, A, &jacInner, nullptr,
+                                    passedInterpData);
+      return getInterpolatedNoiseModel(jacInner, passedInterpData->condCovs);
+    }
+
+    std::unordered_map<StateData, Matrix2N> localInterpCondCovs;
+    b = -computeInterpolatedError(values, A, &jacInner, &localInterpCondCovs);
+    return getInterpolatedNoiseModel(jacInner, localInterpCondCovs);
+  }
+
+  /// Build a JacobianFactor from outer Jacobians and residual.
+  std::shared_ptr<GaussianFactor> makeJacobianFactor(
+      std::vector<Matrix>& A, Vector& b,
+      const noiseModel::Gaussian::shared_ptr& noise_model) const {
+    noise_model->WhitenSystem(A, b);
+
+    std::vector<std::pair<Key, Matrix>> terms(size());
+    for (size_t j = 0; j < size(); ++j) {
+      terms[j].first = keys()[j];
+      terms[j].second.swap(A[j]);
+    }
+
+    using noiseModel::Constrained;
+    if (noiseModel_ && noiseModel_->isConstrained()) {
+      return std::make_shared<JacobianFactor>(
+          terms, b, std::static_pointer_cast<Constrained>(noiseModel_)->unit());
+    }
+    return std::make_shared<JacobianFactor>(terms, b);
+  }
+
+  /// Compute scalar error from residual and Gaussian noise model.
+  double loss(const Vector& b,
+              const noiseModel::Gaussian::shared_ptr& noise_model) const {
+    if (noise_model)
+      return noise_model->loss(noise_model->squaredMahalanobisDistance(b));
+    return 0.5 * b.squaredNorm();
+  }
+
   /**
    * @brief Core routine that evaluates the inner factor on interpolated states
    * and maps results to the outer state ordering.

--- a/gtsam/nonlinear/tests/testWNOAInterpFactor.cpp
+++ b/gtsam/nonlinear/tests/testWNOAInterpFactor.cpp
@@ -197,8 +197,7 @@ TEST(WNOAInterp, EvalErrorP3Unary) {
   // CHECK(assert_equal(residual2, res_actual, 1e-12));
 }
 
-/* *************************************************************************
- */
+/* *********************************************************************** */
 #ifdef GTSAM_ROT3_EXPMAP
 TEST(WNOAInterp, EvalErrorSE3UnaryPose) {
   // Model
@@ -225,8 +224,7 @@ TEST(WNOAInterp, EvalErrorSE3UnaryPose) {
 }
 #endif
 
-/* *************************************************************************
- */
+/* *********************************************************************** */
 
 #ifdef GTSAM_ROT3_EXPMAP
 TEST(WNOAInterp, EvalErrorSE3BetweenPose) {
@@ -254,8 +252,7 @@ TEST(WNOAInterp, EvalErrorSE3BetweenPose) {
   auto res_interp = factor.unwhitenedError(values);               // new
   CHECK(assert_equal(res_btwn, res_interp, 1e-12));
 }
-/* *************************************************************************
- */
+/* *********************************************************************** */
 TEST(WNOAInterp, EvalErrorSE3BtwnInterp) {
   // Same as between above, but using two interpolated states with different
   // boundaries
@@ -291,8 +288,7 @@ TEST(WNOAInterp, EvalErrorSE3BtwnInterp) {
   CHECK(assert_equal(res_btwn, res_btwn_interp, 1e-12));
 }
 #endif
-/* *************************************************************************
- */
+/* *********************************************************************** */
 TEST(WNOAInterp, JacobianPoint3UnaryPose) {
   // Model
   const auto model = noiseModel::Diagonal::Sigmas(Vector3::Ones());
@@ -352,8 +348,91 @@ TEST(WNOAInterp, JacobianPoint3UnaryPose) {
   EXPECT(assert_equal(Jacs[V(2)], J_v2_num, tol));
 }
 
-/* *************************************************************************
- */
+/* *********************************************************************** */
+template <class PoseType>
+typename WNOAInterpFactor<PoseType>::PassedInterpData makePassedInterpData(
+    const WNOAInterpFactor<PoseType>& factor, const Values& values,
+    const Eigen::Matrix<double, traits<PoseType>::dimension, 1>& q_psd_diag) {
+  using VelocityType = typename traits<PoseType>::TangentVector;
+  using PassedInterpData =
+      typename WNOAInterpFactor<PoseType>::PassedInterpData;
+
+  PassedInterpData data;
+  Interpolator<PoseType> interpolator(q_psd_diag);
+
+  for (const auto& [interp_state, border_states] :
+       factor.getInterpToBorders()) {
+    const auto& [left, right] = border_states;
+
+    const auto state_left = TimestampedPoseVelocity<PoseType>(
+        values.at<PoseType>(left.pose), values.at<VelocityType>(left.velocity),
+        left.time);
+    const auto state_right = TimestampedPoseVelocity<PoseType>(
+        values.at<PoseType>(right.pose),
+        values.at<VelocityType>(right.velocity), right.time);
+
+    vector<Matrix> H(8);
+    const auto result = interpolator.interpolatePoseAndVelocity(
+        state_left, state_right, interp_state.time, &H);
+
+    data.values.insert(interp_state.pose, result.pose);
+    data.values.insert(interp_state.velocity, result.vel);
+    data.jacobians[interp_state.pose] = {H[0], H[1], H[2], H[3]};
+    data.jacobians[interp_state.velocity] = {H[4], H[5], H[6], H[7]};
+
+    const auto state_tau =
+        TimestampedPoseVelocity<PoseType>(result, interp_state.time);
+    data.condCovs[interp_state] =
+        interpolator.computeConditionalCov(state_left, state_right, state_tau);
+  }
+
+  return data;
+}
+
+TEST(WNOAInterp, PassedInterpDataPoint3Unary) {
+  // Model
+  const auto model = noiseModel::Diagonal::Sigmas(Vector3::Ones());
+  const auto prior_factor =
+      std::make_shared<PriorFactor<Point3>>(P(1), p1_p3, model);
+  const auto factor = WNOAInterpFactor<Point3>(prior_factor, estimatedStates,
+                                               interpolatedStates, Q_p3);
+  const auto factor_fixed = WNOAInterpFactor<Point3>(
+      prior_factor, estimatedStates, interpolatedStates, Q_p3, true);
+
+  // Set up values
+  Values values;
+  values.insert(P(0), p0_p3);
+  values.insert(P(2), p2_p3);
+  values.insert(V(0), v0_p3);
+  values.insert(V(2), v2_p3);
+
+  auto passed_interp_data = makePassedInterpData(factor, values, Vector3(Q_p3));
+
+  // Check error overload parity
+  DOUBLES_EQUAL(factor.error(values), factor.error(values, &passed_interp_data),
+                1e-12);
+  DOUBLES_EQUAL(factor_fixed.error(values),
+                factor_fixed.error(values, &passed_interp_data), 1e-12);
+
+  // Check linearize overload parity
+  const auto linearized =
+      dynamic_pointer_cast<JacobianFactor>(factor.linearize(values));
+  const auto linearized_passed = dynamic_pointer_cast<JacobianFactor>(
+      factor.linearize(values, &passed_interp_data));
+  const auto linearized_fixed =
+      dynamic_pointer_cast<JacobianFactor>(factor_fixed.linearize(values));
+  const auto linearized_fixed_passed = dynamic_pointer_cast<JacobianFactor>(
+      factor_fixed.linearize(values, &passed_interp_data));
+
+  CHECK(linearized);
+  CHECK(linearized_passed);
+  CHECK(linearized_fixed);
+  CHECK(linearized_fixed_passed);
+  CHECK(linearized->equals(*linearized_passed, 1e-12));
+  CHECK(linearized_fixed->equals(*linearized_fixed_passed, 1e-12));
+}
+
+/* *********************************************************************** */
 #ifdef GTSAM_ROT3_EXPMAP
 TEST(WNOAInterp, JacobianSE3UnaryPose) {
   // Model
@@ -413,8 +492,7 @@ TEST(WNOAInterp, JacobianSE3UnaryPose) {
   EXPECT(assert_equal(Jacs[P(2)], J_p2_num, tol));
   EXPECT(assert_equal(Jacs[V(2)], J_v2_num, tol));
 }
-/* *************************************************************************
- */
+/* *********************************************************************** */
 TEST(WNOAInterp, PrecomputeLambdaPsiUnarySe3) {
   // Model
   const auto model = noiseModel::Diagonal::Sigmas(Vector6::Ones());
@@ -451,8 +529,7 @@ TEST(WNOAInterp, PrecomputeLambdaPsiUnarySe3) {
 }
 #endif
 
-/* *************************************************************************
- */
+/* *********************************************************************** */
 
 TEST(WNOAInterp, Interpolator) {
   // Create Interpolator
@@ -496,8 +573,7 @@ TEST(WNOAInterp, Interpolator) {
   EXPECT(assert_equal(H[3], J_v2_num, tol));
 }
 
-/* *************************************************************************
- */
+/* *********************************************************************** */
 #ifdef GTSAM_ROT3_EXPMAP
 TEST(WNOAInterp, NoiseModelSE3Unary) {
   // Model
@@ -524,8 +600,7 @@ TEST(WNOAInterp, NoiseModelSE3Unary) {
   EXPECT(assert_equal(cov_fixed, cov_prior));
   EXPECT(assert_inequal(cov, cov_prior));
 }
-/* *************************************************************************
- */
+/* *********************************************************************** */
 
 TEST(WNOAInterp, NoiseModelSE3Btwn) {
   // Same as between above, but using two interpolated states with different
@@ -566,8 +641,7 @@ TEST(WNOAInterp, NoiseModelSE3Btwn) {
 }
 #endif
 
-/* *************************************************************************
- */
+/* *********************************************************************** */
 
 TEST(WNOAInterp, NoiseModelP3Btwn) {
   // Same as between above, but using two interpolated states with different
@@ -612,8 +686,7 @@ TEST(WNOAInterp, NoiseModelP3Btwn) {
   EXPECT(assert_equal(cov_diff, 2 * Sigma_tau.block<3, 3>(0, 0)));
 }
 
-/* *************************************************************************
- */
+/* *********************************************************************** */
 #ifdef GTSAM_ROT3_EXPMAP
 
 TEST(WNOAInterp, LinearizeSE3Btwn) {
@@ -651,8 +724,7 @@ TEST(WNOAInterp, LinearizeSE3Btwn) {
   EXPECT(assert_equal(error, Vector6::Zero().eval()));
 }
 
-/* *************************************************************************
- */
+/* *********************************************************************** */
 
 TEST(WNOAInterp, SE3OptimTest) {
   // Define optimization:


### PR DESCRIPTION
This PR contains one follow-up commit.

- refactored the duplicated WNOAInterpFactor linearize/error overload logic into smaller internal helpers
- kept the public API unchanged
- added direct test coverage for the refactored overload pairs using PassedInterpData, following the existing test style closely

The added test checks parity for:
- error(values) vs error(values, &passedInterpData)
- linearize(values) vs linearize(values, &passedInterpData)
- both fixed-noise and non-fixed-noise configurations

Validation run locally:
- make -j6 testWNOAInterpFactor.run

This should be easy to review or cherry-pick as a single focused cleanup plus coverage commit.